### PR TITLE
忽略 AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ launcher_config.json
 .production
 release/
 runtime/
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add AGENTS.md to .gitignore so local contributor-agent guides stay untracked.

## Verification
- Ran git check-ignore -v AGENTS.md locally.