### PR TITLE
记忆整理 daemon 修复：候选消费记账消除无限重复送 LLM + 预算语义归位 + 任务轮转防饥饿

### DIFF
--- a/agent-core/src/db/index.js
+++ b/agent-core/src/db/index.js
@@ -711,6 +711,12 @@ function initSchema(db) {
   // 迁移: 记忆 v3 —— 多重表示 + 双时态演化 + 实体/三元组索引层（见 docs/memory-upgrade-plan.md）
   migrateChatMemoryV3Schema(db);
 
+  // 迁移: 记忆整理记账表（防同一批候选被反复送进 LLM）+ 整理/审计表维护索引
+  migrateMemoryConsolidationMarks(db);
+
+  // 迁移: 把整理 daemon 的显式配置写进既有 memory_settings 行（缺失才补，不覆盖用户值）
+  migrateMemoryConsolidationSettings(db);
+
   // 迁移: 叫醒系统 — characters 表新增 wake 相关列
   migrateWakeSchema(db);
 
@@ -2132,6 +2138,85 @@ export function migrateChatMemoryV3Schema(db) {
   } catch (err) {
     console.error('[db] migrateChatMemoryV3Schema error:', err.message);
     throw err;
+  }
+}
+
+// 迁移: 记忆整理"已处理"记账表 + 维护索引。
+//
+// 背景：T1/T2/T4/T5 的候选发现只按时间窗/状态筛选，模型判定"无关 / 归纳不出结论 / 补不出字段"
+// 时不产生任何内容写入，候选就不会消失——daemon 每轮扫描（默认 5 分钟、空闲时全程为真）
+// 会把同一批候选重复送进 LLM。本表按 (job_type, mark_key) 记账并带 TTL
+// （TTL 常量见 services/memory/memoryConsolidation.js），过期行由 T3 维护清理删除。
+//
+// 键约定：conflict=memory_id、generalize=会话|实体|主体、portrait_suggest=会话、backfill=memory_id。
+// 导出供迁移回归测试使用（test/memoryConsolidationMarks.test.js）。
+export function migrateMemoryConsolidationMarks(db) {
+  try {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS memory_consolidation_marks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        job_type TEXT NOT NULL,
+        mark_key TEXT NOT NULL,
+        marked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(job_type, mark_key)
+      );
+      CREATE INDEX IF NOT EXISTS idx_memory_consolidation_jobs_type
+        ON memory_consolidation_jobs(job_type, status, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_memory_retrieval_audits_created
+        ON memory_retrieval_audits(created_at);
+    `);
+  } catch (err) {
+    console.error('[db] migrateMemoryConsolidationMarks error:', err.message);
+    throw err;
+  }
+}
+
+// 迁移: 把整理 daemon 的显式配置写进既有 memory_settings 行。
+//
+// 背景：memory_settings 只在首次运行时 INSERT OR IGNORE，老库里根本没有 consolidation 块，
+// 一直靠 normalizeMemorySettings 的默认值兜底——库里看不出实际生效的节奏，旧键
+// dailyMaxLlmCalls（语义本就是"每日总量"）也一直残留。这里做一次幂等的显式化：
+//   - 只动 consolidation 一个键，其余配置逐字保留；
+//   - dailyMaxLlmCalls → dailyLlmCalls（语义归位，避免被读成"每轮预算"）；
+//   - 已有值不覆盖（用户手改过就以用户为准），只补缺失键。
+// 全新库由 migrateChatMemoryV2Schema 的种子行覆盖，本函数直接跳过。
+// 注意：这里的数值不在这里做钳制，读取侧 memoryConfig.normalizeMemorySettings 统一钳制。
+// 导出供迁移回归测试使用（test/consolidation.test.js）。
+export function migrateMemoryConsolidationSettings(db) {
+  try {
+    const row = db.prepare(`SELECT setting_value FROM system_settings WHERE setting_key = 'memory_settings'`).get();
+    if (!row) return { skipped: 'no-settings' };
+
+    let stored = {};
+    try { stored = JSON.parse(row.setting_value) || {}; } catch { stored = {}; }
+    const current = stored.consolidation && typeof stored.consolidation === 'object' && !Array.isArray(stored.consolidation)
+      ? stored.consolidation
+      : {};
+
+    const fields = ['enabled', 'idleDelayMinutes', 'minIntervalMinutes', 'llmCallsPerRun', 'dailyLlmCalls', 'portraitSuggest'];
+    const missing = fields.some(field => current[field] === undefined);
+    const hasLegacyKey = current.dailyMaxLlmCalls !== undefined;
+    if (!missing && !hasLegacyKey) return { skipped: 'up-to-date' };
+
+    const next = {
+      enabled: current.enabled === undefined ? true : Boolean(current.enabled),
+      idleDelayMinutes: current.idleDelayMinutes === undefined ? 30 : current.idleDelayMinutes,
+      minIntervalMinutes: current.minIntervalMinutes === undefined ? 60 : current.minIntervalMinutes,
+      llmCallsPerRun: current.llmCallsPerRun === undefined ? 3 : current.llmCallsPerRun,
+      dailyLlmCalls: current.dailyLlmCalls ?? current.dailyMaxLlmCalls ?? 60,
+      // 用户显式关过 T4 就必须保留：白名单漏掉这个键会把「关」悄悄改回「开」
+      portraitSuggest: current.portraitSuggest === undefined ? true : Boolean(current.portraitSuggest),
+    };
+    stored.consolidation = next;
+    db.prepare(`
+      UPDATE system_settings SET setting_value = ?, updated_at = CURRENT_TIMESTAMP WHERE setting_key = 'memory_settings'
+    `).run(JSON.stringify(stored));
+    console.log(`[db] migrateMemoryConsolidationSettings: consolidation 已显式化 ${JSON.stringify(next)}`);
+    return { updated: true, consolidation: next };
+  } catch (err) {
+    // 配置显式化失败不应阻止启动：读取侧仍有默认值兜底
+    console.warn('[db] migrateMemoryConsolidationSettings skipped:', err.message);
+    return { error: err.message };
   }
 }
 

--- a/agent-core/src/routes/groups.js
+++ b/agent-core/src/routes/groups.js
@@ -20,6 +20,7 @@ import { undoLastGroupRound } from '../services/groupRoundUndo.js';
 import { clearConversationMemories } from '../services/memory/memoryRepository.js';
 import { broadcast } from '../services/unifiedStreamBus.js';
 import { beginTurn } from '../services/llmTelemetry.js';
+import { chatStreamStarted, chatStreamEnded } from '../services/chatActivity.js';
 
 const router = Router();
 
@@ -256,6 +257,8 @@ router.post('/:id/nudge', async (req, res) => {
   if (isGroupRoundRunning(groupId)) return res.json({ ok: false, busy: true });
 
   beginTurn(groupConvId(groupId));
+  // 冷场续聊同样是一轮真实群聊生成：登记为活跃流，整理 daemon 让路
+  chatStreamStarted();
   try {
     const { messages, busy } = await runGroupRound(groupId, {
       trigger: 'lull',
@@ -271,6 +274,8 @@ router.post('/:id/nudge', async (req, res) => {
   } catch (err) {
     console.error(`[groups] nudge error for group ${groupId}:`, err.message);
     res.status(500).json({ error: err.message });
+  } finally {
+    chatStreamEnded();
   }
 });
 
@@ -300,6 +305,9 @@ router.post('/:id/chat', async (req, res) => {
   });
   req.socket.setTimeout(0);
   res.setTimeout(0);
+  // 登记为"活跃前台聊天流"：记忆整理 daemon 据此让路（1v1 聊天在 chat.js 同样登记）
+  chatStreamStarted();
+  res.on('close', () => chatStreamEnded());
   const send = (event, data) => res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
 
   try {

--- a/agent-core/src/services/memory/activeSearch.js
+++ b/agent-core/src/services/memory/activeSearch.js
@@ -5,7 +5,7 @@
 // 3. 实体 1 跳扩展：已命中记忆的共享实体反查关联记忆
 // 4. RRF 融合 → [{ injectionText, isHistorical, ... }]，注入 <memory_recall_result> 二次续写
 import { getDb } from '../../db/index.js';
-import { hybridSearch, rrfFusion, formatRow } from '../memorySearch.js';
+import { hybridSearch, rrfFusion, formatRow, auditQueryText } from '../memorySearch.js';
 import { vectorSearch } from '../vectorClient.js';
 import { embedMemoryText } from './memoryProviders.js';
 import { getMemorySettings, isMemoryV3Enabled } from './memoryConfig.js';
@@ -250,7 +250,7 @@ function writeActiveAudit({ conversationIds, query, primary, tripleResults, enti
       VALUES (?, ?, 'active', ?, ?, ?)
     `).run(
       conversationScope,
-      String(query).slice(0, 1000),
+      auditQueryText(query),
       JSON.stringify(counts),
       JSON.stringify(results.map(item => item.memory_id)),
       null,

--- a/agent-core/src/services/memory/consolidationScheduler.js
+++ b/agent-core/src/services/memory/consolidationScheduler.js
@@ -2,17 +2,28 @@
  * Memory v3 阶段三：整理 daemon 调度器（记忆的"睡眠期"）
  * docs/memory-upgrade-plan.md §6.1
  *
- * 触发模型：
- *   - 每 5 分钟扫描一次；
- *   - 空闲判定通过才执行：无活跃聊天流（chatActivity）且距最后一条消息 ≥ idleDelayMinutes（默认 30 分钟）；
- *   - 每日兜底：距上次成功运行 > 22 小时时，即便不够空闲也执行（但聊天进行中仍然让路）；
- *   - daemon 永不在聊天进行中触发 LLM 调用。
+ * 触发模型（四道闸门，逐级收紧）：
+ *   1. 每 5 分钟扫描一次，但只有"空闲"才继续：无活跃前台聊天流（chatActivity）
+ *      且距最后一条消息 ≥ idleDelayMinutes（默认 30 分钟）；
+ *   2. 两次"真正干过活"的整理之间至少间隔 minIntervalMinutes（默认 60 分钟）——
+ *      空闲判定在用户离开后会恒为真，没有这道闸门就等于"每 5 分钟一整轮"；
+ *   3. 每日兜底：距上次真正干过活 > 22 小时时，即便不够空闲也执行（聊天进行中仍然让路）；
+ *   4. 上一轮什么都没干成 → 退避 30 分钟，避免空转轮把候选发现查询每 5 分钟跑一遍。
+ *
+ * LLM 预算双层：
+ *   - 单轮上限 llmCallsPerRun（默认 3）；
+ *   - 每日总量 dailyLlmCalls（默认 60，跨轮累计、按上海日期归零、持久化在 state.daily）。
+ *   旧配置键 dailyMaxLlmCalls 的语义本就是"每日总量"，由 memoryConfig 归位到 dailyLlmCalls。
  *
  * 任务队列：memory_consolidation_jobs（job_type/payload/status/attempts）。
  *   - 扫描时按候选发现结果入队（同类型已有 pending/processing 则不重复入队）；
- *   - SQL 任务（decay/tombstone）优先领取，LLM 任务受单轮预算 llmCallsPerRun 约束；
+ *   - SQL 任务（decay/tombstone）优先领取；同优先级内按"该类型上次完成时间"轮转，
+ *     避免 T1/T2 长期吃满预算把 T4/T5 饿死；
  *   - 预算耗尽而任务未完成 → 留在 pending（或补一个后续任务），下次扫描自然续跑；
  *   - 启动时 processing → pending 恢复（kill 后续跑）；attempts ≥ 3 → failed 不再自动重试。
+ *
+ * 候选消费记账：见 memoryConsolidation.js 的 RECONSOLIDATE_AFTER_DAYS / markConsolidated——
+ * 模型判定"无关/无需泛化/补不出字段"时同样记账，否则同一批候选会被无限重复送进 LLM。
  *
  * 运行状态写入 system_settings('memory_consolidation_state')，管理接口可查。
  */
@@ -44,13 +55,11 @@ import {
 } from './memoryRepository.js';
 
 const SCAN_INTERVAL_MS = 5 * 60 * 1000;       // 扫描周期
-const DAILY_FALLBACK_HOURS = 22;              // 每日兜底线
+const DAILY_FALLBACK_HOURS = 22;              // 每日兜底线（锚在"上次真正干过活"）
 const STARTUP_DELAY_MS = 2 * 60 * 1000;       // 启动后首次扫描延迟
 const MAX_ATTEMPTS = 3;                       // 任务失败重试上限
+const EMPTY_SCAN_BACKOFF_MS = 30 * 60 * 1000; // 空转轮退避
 const STATE_KEY = 'memory_consolidation_state';
-
-// SQL 任务（零 LLM）永远先于 LLM 任务执行，保证预算紧张时免费任务不被饿死
-const FREE_JOB_TYPES = new Set(['decay', 'tombstone']);
 
 let timer = null;
 let executing = false;
@@ -74,6 +83,49 @@ function writeState(patch) {
     ON CONFLICT(setting_key) DO UPDATE SET setting_value = excluded.setting_value, updated_at = CURRENT_TIMESTAMP
   `).run(STATE_KEY, JSON.stringify(next));
   return next;
+}
+
+// 每日额度按上海日期归零（与 memoryProviders 的失败计数同口径）
+export function shanghaiDateKey(now = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Shanghai', year: 'numeric', month: '2-digit', day: '2-digit',
+  }).formatToParts(now);
+  const value = Object.fromEntries(parts.map(part => [part.type, part.value]));
+  return `${value.year}-${value.month}-${value.day}`;
+}
+
+export function readDailyUsage(state, now = new Date()) {
+  const date = shanghaiDateKey(now);
+  const used = state.daily?.date === date ? Math.max(0, Number(state.daily.used) || 0) : 0;
+  return { date, used };
+}
+
+/**
+ * 运行闸门决策（纯函数，便于单测）。三道时间闸门都在这里：
+ *   1. not-idle        —— 不空闲且距上次实干 < 22h
+ *   2. min-interval    —— 距上次实干 < minIntervalMinutes（空闲判定在用户离开后恒为真，
+ *                         没有这道闸门就等于每 5 分钟一满轮）
+ *   3. scan-backoff    —— 上一轮空手而归且退避期未过（避免空转轮反复做候选发现全表扫描）
+ * 返回 { run: true } 或 { run: false, skipped }。force 由调用方绕过本函数。
+ */
+export function evaluateRunGates({ state = {}, cfg = {}, idle = false, now = Date.now() } = {}) {
+  const withinMs = (iso, windowMs) => {
+    if (!iso) return false;
+    const parsed = new Date(iso).getTime();
+    if (Number.isNaN(parsed)) return false;
+    return now - parsed < windowMs;
+  };
+  // 不空闲时：距上次实干 < 22h 就让路；≥ 22h 走每日兜底（state 里没有实干记录则视为需要兜底）
+  if (!idle && withinMs(state.lastWorkedAt, DAILY_FALLBACK_HOURS * 3600000)) {
+    return { run: false, skipped: 'not-idle' };
+  }
+  if (withinMs(state.lastWorkedAt, Math.max(0, Number(cfg.minIntervalMinutes) || 0) * 60000)) {
+    return { run: false, skipped: 'min-interval' };
+  }
+  if (withinMs(state.lastEmptyScanAt, EMPTY_SCAN_BACKOFF_MS)) {
+    return { run: false, skipped: 'scan-backoff' };
+  }
+  return { run: true };
 }
 
 // ── 空闲判定 ──
@@ -138,8 +190,8 @@ export function isLlmJobCoolingDown(db, jobType, now = Date.now()) {
 
 /**
  * 候选发现 + 入队。SQL 任务按时间节流（decay 6h / tombstone 24h），
- * LLM 任务只在"确实有活干"时入队；T4 再按天冷却——它的候选查询对同一批记忆恒为真，
- * 不冷却就会每轮扫描都重跑同一个角色。
+ * LLM 任务只在“确实有活干”时入队；候选是否重复由 memoryConsolidation 的记账表负责（分任务 TTL），
+ * T4 另有一层按天冷却兜底——它的候选查询对同一批记忆恒为真。
  */
 export function discoverAndEnqueueJobs(db, llmBudget, { portraitSuggest = isPortraitSuggestionEnabled(), v3Enabled = isMemoryV3Enabled() } = {}) {
   if (!hasOpenJob(db, 'decay') && completedBefore(db, 'decay', 6 * 3600 * 1000)) {
@@ -164,11 +216,22 @@ export function discoverAndEnqueueJobs(db, llmBudget, { portraitSuggest = isPort
   }
 }
 
+/**
+ * 领取下一个 pending 任务。
+ * 排序：SQL 任务永远优先；同为 LLM 任务时按"该类型上次完成时间"升序轮转——
+ * 原先只按 id 升序会让 conflict/generalize 稳定吃满预算，portrait_suggest/backfill 永远排不上。
+ */
 function claimNextJob(db) {
   return db.transaction(() => {
     const job = db.prepare(`
-      SELECT * FROM memory_consolidation_jobs WHERE status = 'pending'
-      ORDER BY CASE WHEN job_type IN ('decay', 'tombstone') THEN 0 ELSE 1 END, id ASC LIMIT 1
+      SELECT pj.* FROM memory_consolidation_jobs pj
+      WHERE pj.status = 'pending'
+      ORDER BY
+        CASE WHEN pj.job_type IN ('decay', 'tombstone') THEN 0 ELSE 1 END,
+        (SELECT COALESCE(MAX(hist.updated_at), '') FROM memory_consolidation_jobs hist
+          WHERE hist.job_type = pj.job_type AND hist.status = 'completed') ASC,
+        pj.id ASC
+      LIMIT 1
     `).get();
     if (!job) return null;
     const claimed = db.prepare(`
@@ -230,23 +293,29 @@ export async function runConsolidationOnce({ force = false } = {}) {
 
   const state = readState();
   const idle = isIdleForConsolidation(cfg.idleDelayMinutes);
-  const hoursSinceRun = state.lastFinishedAt ? (Date.now() - new Date(state.lastFinishedAt).getTime()) / 3600000 : Infinity;
-  if (!force && !idle && hoursSinceRun < DAILY_FALLBACK_HOURS) return { skipped: 'not-idle' };
+  if (!force) {
+    const gate = evaluateRunGates({ state, cfg, idle });
+    if (!gate.run) return { skipped: gate.skipped };
+  }
 
   if (executing) return { skipped: 'already-running' };
   executing = true;
   const summary = {};
+  let jobsExecuted = 0;
+  let llmCallsUsed = 0;
   try {
+    const daily = readDailyUsage(state);
+    const dailyRemaining = Math.max(0, cfg.dailyLlmCalls - daily.used);
+    const llmBudgetForRun = Math.min(cfg.llmCallsPerRun, dailyRemaining);
     recoverInterruptedJobs(db);
-    discoverAndEnqueueJobs(db, cfg.llmCallsPerRun, { portraitSuggest: cfg.portraitSuggest });
-    let llmCallsUsed = 0;
+    discoverAndEnqueueJobs(db, llmBudgetForRun, { portraitSuggest: cfg.portraitSuggest });
     while (true) {
       const job = claimNextJob(db);
       if (!job) break;
       const isLlmJob = LLM_JOB_TYPES.has(job.job_type);
-      const budgetRemaining = Math.max(0, cfg.llmCallsPerRun - llmCallsUsed);
+      const budgetRemaining = Math.max(0, llmBudgetForRun - llmCallsUsed);
       if (isLlmJob && budgetRemaining === 0) {
-        // 预算耗尽：任务退回 pending，下轮扫描续跑
+        // 预算耗尽：任务退回 pending，下轮扫描续跑（SQL 任务排序在前，不会被这里挡住）
         db.prepare(`UPDATE memory_consolidation_jobs SET status = 'pending', updated_at = CURRENT_TIMESTAMP WHERE id = ?`).run(job.id);
         break;
       }
@@ -254,10 +323,11 @@ export async function runConsolidationOnce({ force = false } = {}) {
         const result = await executeJob(job, { llmBudgetRemaining: budgetRemaining, db, portraitSuggest: cfg.portraitSuggest });
         llmCallsUsed += result.llmCalls || 0;
         // LLM 任务因预算中途让位 → 补一个后续任务（下轮接着跑剩余候选）
-        if (isLlmJob && result.done === false && cfg.llmCallsPerRun - llmCallsUsed <= 0) {
+        if (isLlmJob && result.done === false && llmBudgetForRun - llmCallsUsed <= 0) {
           enqueueJob(db, job.job_type, { continuation: true });
         }
         finishJob(db, job.id, 'completed');
+        jobsExecuted++;
         summary[job.job_type] = result;
         console.log(`[consolidation] job ${job.job_type}#${job.id} completed:`, JSON.stringify(result).slice(0, 300));
       } catch (error) {
@@ -268,8 +338,28 @@ export async function runConsolidationOnce({ force = false } = {}) {
       }
     }
     if (llmCallsUsed > 0) notifyMemoryIndexWorker();
-    writeState({ lastFinishedAt: new Date().toISOString(), lastRunIdle: idle, llmCallsUsed, summary });
-    return { ok: true, idle, llmCallsUsed, summary };
+    const nowIso = new Date().toISOString();
+    const worked = jobsExecuted > 0;
+    writeState({
+      lastFinishedAt: nowIso,
+      ...(worked ? { lastWorkedAt: nowIso, lastEmptyScanAt: null } : { lastEmptyScanAt: nowIso }),
+      lastRunIdle: idle,
+      llmCallsUsed,
+      llmCallsPerRun: llmBudgetForRun,
+      dailyLlmCalls: cfg.dailyLlmCalls,
+      dailyMaxLlmCalls: undefined,
+      daily: { date: daily.date, used: daily.used + llmCallsUsed },
+      summary,
+    });
+    return {
+      ok: true,
+      idle,
+      jobsExecuted,
+      llmCallsUsed,
+      dailyLlmCallsUsed: daily.used + llmCallsUsed,
+      dailyLlmCalls: cfg.dailyLlmCalls,
+      summary,
+    };
   } finally {
     executing = false;
   }
@@ -289,7 +379,7 @@ export function startConsolidationScheduler() {
   setTimeout(() => {
     runConsolidationOnce().catch(error => console.warn('[consolidation] first scan failed:', error.message));
   }, STARTUP_DELAY_MS).unref();
-  console.log('[consolidation] scheduler started (scan every 5min, idle-gated)');
+  console.log('[consolidation] scheduler started (scan every 5min, idle+min-interval gated, daily LLM budget)');
 }
 
 export function stopConsolidationScheduler() {

--- a/agent-core/src/services/memory/memoryConfig.js
+++ b/agent-core/src/services/memory/memoryConfig.js
@@ -24,11 +24,13 @@ export const DEFAULT_MEMORY_SETTINGS = Object.freeze({
   // 阶段二：@memory 主动回想（默认关，灰度放量；docs/memory-upgrade-plan.md §5）
   activeSearch: { enabled: false, timeoutMs: 4000 },
   // 阶段三：整理 daemon（记忆的"睡眠期"；docs/memory-upgrade-plan.md §6）。
-  // llmCallsPerRun 是"每轮整理"的调用预算（每 5 分钟一轮、每轮重置），并非每日总量；
-  // 旧配置键 dailyMaxLlmCalls 由 normalizeMemorySettings 兼容读取。
-  // T4 画像升华（portrait_suggest）默认关：旧实现会对同一批记忆反复重跑、产出换词重述的
-  // 近似建议；保留开关与实现，等改成「新记忆触发 + 向量去重 + 拒绝反馈」后再放量。
-  consolidation: { enabled: true, idleDelayMinutes: 30, llmCallsPerRun: 6, portraitSuggest: false },
+  //   minIntervalMinutes 两次“真正干过活”的整理之间的最小间隔（防用户离开后每 5 分钟一整轮）
+  //   llmCallsPerRun    单轮整理的 LLM 调用上限
+  //   dailyLlmCalls     每日 LLM 调用总量（跨轮累计、按上海日期归零）
+  // 旧配置键 dailyMaxLlmCalls 的语义本就是“每日总量”，统一归位到 dailyLlmCalls。
+  // T4 画像升华（portrait_suggest）默认开启：候选消费记账（memory_consolidation_marks，14 天 TTL）
+  // 已从根上消除“同一批候选每轮重复送 LLM”，不再需要按天冷却或默认关闭；开关保留，可随时关。
+  consolidation: { enabled: true, idleDelayMinutes: 30, minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60, portraitSuggest: true },
   // 阶段四：dynamicBlocks token 预算（默认关；docs/memory-upgrade-plan.md §7）
   contextBudget: { enabled: false, dynamicTokens: 8000 },
   embedding: {
@@ -88,14 +90,21 @@ export function normalizeMemorySettings(input = {}, previous = null) {
     consolidation: {
       enabled: consolidation.enabled === undefined ? (base.consolidation?.enabled ?? true) : Boolean(consolidation.enabled),
       idleDelayMinutes: clampInt(consolidation.idleDelayMinutes, base.consolidation?.idleDelayMinutes ?? 30, 5, 720),
-      // 旧键 dailyMaxLlmCalls 兼容读取（实际语义是每轮预算，改名以正名）
-      llmCallsPerRun: clampInt(
-        consolidation.llmCallsPerRun ?? consolidation.dailyMaxLlmCalls,
-        base.consolidation?.llmCallsPerRun ?? base.consolidation?.dailyMaxLlmCalls ?? 6,
-        0, 30,
+      minIntervalMinutes: clampInt(
+        consolidation.minIntervalMinutes,
+        base.consolidation?.minIntervalMinutes ?? 60,
+        0, 1440,
+      ),
+      llmCallsPerRun: clampInt(consolidation.llmCallsPerRun, base.consolidation?.llmCallsPerRun ?? 3, 0, 30),
+      // 旧键 dailyMaxLlmCalls → dailyLlmCalls：旧键语义就是"每日总量"，
+      // 此前被误接到"每轮预算"导致默认值被放大 288 倍（每 5 分钟一轮 × 6 次）
+      dailyLlmCalls: clampInt(
+        consolidation.dailyLlmCalls ?? consolidation.dailyMaxLlmCalls,
+        base.consolidation?.dailyLlmCalls ?? base.consolidation?.dailyMaxLlmCalls ?? 60,
+        0, 2000,
       ),
       portraitSuggest: consolidation.portraitSuggest === undefined
-        ? (base.consolidation?.portraitSuggest ?? false)
+        ? (base.consolidation?.portraitSuggest ?? true)
         : Boolean(consolidation.portraitSuggest),
     },
     contextBudget: {
@@ -167,21 +176,23 @@ export function isMemoryActiveSearchEnabled() {
 // 阶段三整理 daemon 配置。DB 未就绪时按默认开启处理（daemon 内部还有空闲判定双重保险）。
 export function getConsolidationConfig() {
   try {
-    const { enabled, idleDelayMinutes, llmCallsPerRun, portraitSuggest } = getMemorySettings().consolidation || {};
+    const { enabled, idleDelayMinutes, minIntervalMinutes, llmCallsPerRun, dailyLlmCalls, portraitSuggest } = getMemorySettings().consolidation || {};
     return {
       enabled: enabled !== false,
       idleDelayMinutes: clampInt(idleDelayMinutes, 30, 5, 720),
-      llmCallsPerRun: clampInt(llmCallsPerRun, 6, 0, 30),
-      portraitSuggest: portraitSuggest === true,
+      minIntervalMinutes: clampInt(minIntervalMinutes, 60, 0, 1440),
+      llmCallsPerRun: clampInt(llmCallsPerRun, 3, 0, 30),
+      dailyLlmCalls: clampInt(dailyLlmCalls, 60, 0, 2000),
+      portraitSuggest: portraitSuggest !== false,
     };
   } catch {
-    return { enabled: true, idleDelayMinutes: 30, llmCallsPerRun: 6, portraitSuggest: false };
+    return { enabled: true, idleDelayMinutes: 30, minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60, portraitSuggest: true };
   }
 }
 
-// T4 画像升华开关（默认关）。DB 未就绪时按关闭处理。
+// T4 画像升华开关（默认开）。DB 未就绪时按开启处理。
 export function isPortraitSuggestionEnabled() {
-  return getConsolidationConfig().portraitSuggest === true;
+  return getConsolidationConfig().portraitSuggest !== false;
 }
 
 // 阶段四 dynamicBlocks token 预算配置。DB 未就绪时按默认关闭处理，零影响。
@@ -226,9 +237,9 @@ export function getEmbeddingProfile(settings = getMemorySettings({ includeSecret
   return { fingerprint, corpus: `memory_v2_${fingerprint}` };
 }
 
-export function getMemoryMode(settings = getMemorySettings({ includeSecrets: true })) {
-  return 'hybrid';
-}
+// 检索模式对外统一报告为 hybrid：文本通道永远可用，向量/实体通道按配置与可用性自行降级
+// （此前是一个恒返回 'hybrid' 的导出函数，收口为常量，避免"看起来可切换"的误导）
+export const MEMORY_MODE = 'hybrid';
 
 function maskSecrets(settings) {
   const copy = JSON.parse(JSON.stringify(settings));
@@ -238,7 +249,7 @@ function maskSecrets(settings) {
     copy[key].apiKeyPreview = secret ? `${secret.slice(0, 3)}***${secret.slice(-2)}` : '';
     copy[key].apiKey = '';
   }
-  copy.mode = getMemoryMode(settings);
+  copy.mode = MEMORY_MODE;
   copy.profile = getEmbeddingProfile(settings)?.fingerprint || null;
   return copy;
 }

--- a/agent-core/src/services/memory/memoryConsolidation.js
+++ b/agent-core/src/services/memory/memoryConsolidation.js
@@ -24,6 +24,65 @@ export const ARCHIVE_THRESHOLD = 0.15;
 // LLM 任务类型集合（调度器据此做预算闸门）
 export const LLM_JOB_TYPES = new Set(['conflict', 'generalize', 'portrait_suggest', 'backfill']);
 
+// ── 整理记账（防止同一批候选被反复送进 LLM）──
+//
+// 候选发现只按时间窗/状态筛选，模型判定"无关 / 归纳不出结论 / 补不出字段"时不产生任何内容写入。
+// 若不做记账，同一批候选会在每轮扫描（默认 5 分钟，用户离开后空闲判定恒为真）里被无限重复送进 LLM。
+// 记账键按任务类型区分：
+//   conflict        → memory_id
+//   generalize      → conversation_id|entity_id|subject（组级：成员会随新记忆变化）
+//   portrait_suggest→ conversation_id
+//   backfill        → memory_id
+// TTL 到期后同一条记忆/组可以被重新整理（内容可能已变化）。
+export const RECONSOLIDATE_AFTER_DAYS = Object.freeze({
+  conflict: 7,
+  generalize: 30,
+  portrait_suggest: 14,
+  backfill: 30,
+});
+
+// 记账行保留期：远超所有 TTL，过期行由 T3 维护清理删除
+export const MARK_RETENTION_DAYS = 180;
+
+// 统一时间形态（与 memory_fragments.created_at 一致：UTC 'YYYY-MM-DD HH:MM:SS' 字符串可比）
+function sqliteTime(date = new Date()) {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function markCutoff(jobType, now = new Date()) {
+  return sqliteTime(new Date(now.getTime() - (RECONSOLIDATE_AFTER_DAYS[jobType] ?? 30) * 86400000));
+}
+
+/** 泛化组的记账键（必须与 findGeneralizationGroups 里的 SQL 拼接表达式逐字一致）。 */
+export function generalizationMarkKey({ conversation_id: conversationId, entity_id: entityId, subject }) {
+  return `${conversationId ?? ''}|${entityId}|${subject ?? ''}`;
+}
+
+/**
+ * 记账：标记"这批候选已经问过模型了"（无论模型给出什么结论）。
+ * 只应在 LLM 成功返回后调用——调用抛错时不记账，下一轮自然重试。
+ */
+export function markConsolidated(db, jobType, keys, { now = new Date() } = {}) {
+  const list = [...new Set((keys || []).map(key => String(key ?? '')).filter(Boolean))];
+  if (!db || list.length === 0) return 0;
+  const at = sqliteTime(now);
+  const stmt = db.prepare(`
+    INSERT INTO memory_consolidation_marks(job_type, mark_key, marked_at) VALUES (?, ?, ?)
+    ON CONFLICT(job_type, mark_key) DO UPDATE SET marked_at = excluded.marked_at
+  `);
+  const tx = db.transaction(() => { for (const key of list) stmt.run(jobType, key, at); });
+  tx();
+  return list.length;
+}
+
+/** 尚未过期（仍在 TTL 内）的记账键，供测试与排查使用。 */
+export function listActiveMarks(db, jobType, { now = new Date() } = {}) {
+  if (!db) return [];
+  return db.prepare(`
+    SELECT mark_key FROM memory_consolidation_marks WHERE job_type = ? AND marked_at >= ?
+  `).all(jobType, markCutoff(jobType, now)).map(row => row.mark_key);
+}
+
 // SQLite 时间统一成可比较/可解析形态（存储里 'T' 与空格两种分隔符并存）
 export function normalizeSqliteTime(value) {
   if (!value) return null;
@@ -81,14 +140,27 @@ export function aggregateRetrievalAudits(db, { sinceDays = 90, now = new Date() 
 /**
  * 遍历全部 active 记忆重算 strength 并写回；低于阈值的 → archived + 向量墓碑。
  * 返回归档明细（可解释：每条含强度构成），供日志与状态汇报。
+ *
+ * 写入约束：只在强度真的变化时才 UPDATE（`strength IS NOT ?`），
+ * 否则每 6 小时一次的全表写会白白放大 WAL 写入量、与聊天写事务抢 SQLite 单写锁。
+ * 语句在循环外 prepare，事务内复用。
  */
 export function decayAndArchiveMemories(db, { now = new Date(), threshold = ARCHIVE_THRESHOLD, enqueueDelete, enqueueTripleDelete } = {}) {
   const rows = db.prepare(`
     SELECT memory_id, memory_type, importance, retrieval_count, embedding_state, chroma_id,
-           last_reinforced_at, event_time, updated_at, created_at
+           last_reinforced_at, event_time, updated_at, created_at, strength
     FROM memory_fragments WHERE status = 'active'
   `).all();
   const archived = [];
+  const updateStrength = db.prepare(`
+    UPDATE memory_fragments SET strength = ? WHERE memory_id = ? AND status = 'active' AND strength IS NOT ?
+  `);
+  const archiveStmt = db.prepare(`
+    UPDATE memory_fragments SET status = 'archived', updated_at = CURRENT_TIMESTAMP WHERE memory_id = ? AND status = 'active'
+  `);
+  const selectTriples = db.prepare(`SELECT id FROM memory_triples WHERE memory_id = ? AND valid_to IS NULL`);
+  const invalidateTriples = db.prepare(`UPDATE memory_triples SET valid_to = CURRENT_TIMESTAMP WHERE memory_id = ? AND valid_to IS NULL`);
+  let strengthened = 0;
   const tx = db.transaction(() => {
     for (const row of rows) {
       const halfLifeDays = HALF_LIFE_DAYS[row.memory_type] ?? 180;
@@ -100,21 +172,23 @@ export function decayAndArchiveMemories(db, { now = new Date(), threshold = ARCH
         halfLifeDays,
         retrievalCount: row.retrieval_count,
       });
-      db.prepare(`UPDATE memory_fragments SET strength = ? WHERE memory_id = ? AND status = 'active'`)
-        .run(Math.round(strength * 10000) / 10000, row.memory_id);
+      const rounded = Math.round(strength * 10000) / 10000;
+      if (rounded !== Number(row.strength)) {
+        updateStrength.run(rounded, row.memory_id, rounded);
+        strengthened++;
+      }
       if (strength >= threshold) continue;
-      db.prepare(`UPDATE memory_fragments SET status = 'archived', updated_at = CURRENT_TIMESTAMP WHERE memory_id = ? AND status = 'active'`)
-        .run(row.memory_id);
+      archiveStmt.run(row.memory_id);
       // 归档即出检索通道：向量墓碑（v3 corpus）；三元组连带失效 + 墓碑
       if (row.embedding_state === 'indexed' || row.chroma_id) enqueueDelete?.(row.memory_id, row);
-      const tripleIds = db.prepare(`SELECT id FROM memory_triples WHERE memory_id = ? AND valid_to IS NULL`).all(row.memory_id);
+      const tripleIds = selectTriples.all(row.memory_id);
       if (tripleIds.length > 0) {
-        db.prepare(`UPDATE memory_triples SET valid_to = CURRENT_TIMESTAMP WHERE memory_id = ? AND valid_to IS NULL`).run(row.memory_id);
+        invalidateTriples.run(row.memory_id);
         for (const triple of tripleIds) enqueueTripleDelete?.(triple.id);
       }
       archived.push({
         memoryId: row.memory_id,
-        strength: Math.round(strength * 10000) / 10000,
+        strength: rounded,
         importance: row.importance,
         halfLifeDays,
         daysSinceAnchor: Math.round(daysSinceAnchor * 10) / 10,
@@ -124,7 +198,27 @@ export function decayAndArchiveMemories(db, { now = new Date(), threshold = ARCH
     }
   });
   tx();
-  return { scanned: rows.length, archived };
+  return { scanned: rows.length, strengthened, archived };
+}
+
+// ── 维护清理：为整理 daemon 产生的辅助数据设保留期（纯 SQL，随 T3 一起跑）──
+
+/**
+ * 审计/任务/记账三类辅助表的保留期清理。
+ * 只删已终结的整理任务行（pending/processing 永不删，避免删掉正在跑的任务）。
+ */
+export function pruneConsolidationArtifacts(db, {
+  now = new Date(),
+  auditRetentionDays = 90,
+  jobRetentionDays = 7,
+  markRetentionDays = MARK_RETENTION_DAYS,
+} = {}) {
+  const olderThan = days => sqliteTime(new Date(now.getTime() - days * 86400000));
+  return {
+    audits: db.prepare(`DELETE FROM memory_retrieval_audits WHERE created_at < ?`).run(olderThan(auditRetentionDays)).changes,
+    jobs: db.prepare(`DELETE FROM memory_consolidation_jobs WHERE status IN ('completed', 'failed') AND updated_at < ?`).run(olderThan(jobRetentionDays)).changes,
+    marks: db.prepare(`DELETE FROM memory_consolidation_marks WHERE marked_at < ?`).run(olderThan(markRetentionDays)).changes,
+  };
 }
 
 // ── T6：向量墓碑一致性扫描（幂等）──
@@ -163,15 +257,20 @@ export function scanVectorTombstones(db, { limit = 200, enqueueDelete, enqueueTr
 
 // ── T1~T5 候选发现（纯查询，供调度器决定是否入队 + runner 消费）──
 
-// T1：近 N 天新建且有实体的记忆 → 各自找共享实体的更早 active 记忆，组成冲突候选簇
+// T1：近 N 天新建且有实体的记忆 → 各自找共享实体的更早 active 记忆，组成冲突候选簇。
+// TTL 内已问过模型的记忆不再入选（否则模型说"无关"后同一簇每轮扫描都会重问）。
 export function findConflictClusters(db, { sinceDays = 7, limit = 4, now = new Date(), maxOldPerCluster = 4 } = {}) {
   const cutoff = new Date(now.getTime() - sinceDays * 86400000).toISOString().slice(0, 19).replace('T', ' ');
   const recent = db.prepare(`
     SELECT mf.* FROM memory_fragments mf
     WHERE mf.status = 'active' AND mf.created_at >= ?
       AND EXISTS (SELECT 1 FROM memory_entity_links mel WHERE mel.memory_id = mf.memory_id)
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_consolidation_marks mcm
+        WHERE mcm.job_type = 'conflict' AND mcm.mark_key = mf.memory_id AND mcm.marked_at >= ?
+      )
     ORDER BY mf.created_at DESC LIMIT 40
-  `).all(cutoff);
+  `).all(cutoff, markCutoff('conflict', now));
   const clusters = [];
   const usedIds = new Set();
   for (const row of recent) {
@@ -211,7 +310,8 @@ function hasLivingGeneralization(db, memberIds) {
 }
 
 // T2：同会话同实体同 subject 的 event/emotion ≥3 条且跨度 > 14 天 → 泛化候选组
-export function findGeneralizationGroups(db, { minCount = 3, spanDays = 14, limit = 2 } = {}) {
+// TTL 内已问过模型的组不再入选（模型明确"归纳不出结论"时同样记账，否则组永不消失）。
+export function findGeneralizationGroups(db, { minCount = 3, spanDays = 14, limit = 2, now = new Date() } = {}) {
   const groups = db.prepare(`
     SELECT mf.conversation_id, mel.entity_id, me.name AS entity_name, mf.subject,
            COUNT(*) AS cnt,
@@ -221,10 +321,15 @@ export function findGeneralizationGroups(db, { minCount = 3, spanDays = 14, limi
     JOIN memory_entity_links mel ON mel.memory_id = mf.memory_id
     JOIN memory_entities me ON me.id = mel.entity_id
     WHERE mf.status = 'active' AND mf.memory_type IN ('event', 'emotion')
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_consolidation_marks mcm
+        WHERE mcm.job_type = 'generalize' AND mcm.marked_at >= ?
+          AND mcm.mark_key = COALESCE(mf.conversation_id, '') || '|' || mel.entity_id || '|' || COALESCE(mf.subject, '')
+      )
     GROUP BY mf.conversation_id, mel.entity_id, mf.subject
     HAVING cnt >= ? AND (julianday(newest) - julianday(oldest)) >= ?
     ORDER BY cnt DESC, me.mention_count DESC LIMIT ?
-  `).all(minCount, spanDays, limit);
+  `).all(markCutoff('generalize', now), minCount, spanDays, limit);
   const result = [];
   for (const group of groups) {
     const members = db.prepare(`
@@ -245,15 +350,21 @@ export function findGeneralizationGroups(db, { minCount = 3, spanDays = 14, limi
 export const PORTRAIT_PENDING_LIMIT = 20;
 
 // T4：importance≥4 的 knowledge 按会话聚合（每会话一次 LLM 调用生成画像建议）。
-// 待确认建议积压达到上限的会话先跳过——同一批记忆反复"升华"只会产出换词重述的近似建议，
-// 等人工确认/忽略掉一批后它自然重新进入候选（也让后面的会话有机会轮转）。
-export function findPortraitSuggestionConversations(db, { minImportance = 4, limit = 2, maxPending = PORTRAIT_PENDING_LIMIT } = {}) {
+// 两道过滤：
+//   1) TTL 内已问过模型的会话不再入选（模型提不出新建议时同样记账，否则同一会话每轮都会被重问）；
+//   2) 待确认建议积压达到上限的会话先跳过——同一批记忆反复“升华”只会产出换词重述的近似建议，
+//      等人工确认/忽略掉一批后它自然重新进入候选（也让后面的会话有机会轮转）。
+export function findPortraitSuggestionConversations(db, { minImportance = 4, limit = 2, maxPending = PORTRAIT_PENDING_LIMIT, now = new Date() } = {}) {
   const rows = db.prepare(`
-    SELECT conversation_id, COUNT(*) AS cnt FROM memory_fragments
-    WHERE status = 'active' AND memory_type = 'knowledge' AND importance >= ?
-      AND substr(conversation_id, 1, 5) = 'char_'
-    GROUP BY conversation_id ORDER BY cnt DESC LIMIT 50
-  `).all(minImportance);
+    SELECT mf.conversation_id, COUNT(*) AS cnt FROM memory_fragments mf
+    WHERE mf.status = 'active' AND mf.memory_type = 'knowledge' AND mf.importance >= ?
+      AND substr(mf.conversation_id, 1, 5) = 'char_'
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_consolidation_marks mcm
+        WHERE mcm.job_type = 'portrait_suggest' AND mcm.mark_key = mf.conversation_id AND mcm.marked_at >= ?
+      )
+    GROUP BY mf.conversation_id ORDER BY cnt DESC LIMIT 50
+  `).all(minImportance, markCutoff('portrait_suggest', now));
   const countPending = db.prepare(`
     SELECT COUNT(*) AS cnt FROM portrait_suggestions WHERE character_id = ? AND status = 'pending'
   `);
@@ -274,17 +385,25 @@ export function findPortraitSuggestionConversations(db, { minImportance = 4, lim
   return result;
 }
 
-// T5：v3 检索字段（keywords/perspectives/semantic_note）全缺失的 active 旧记忆，最旧优先
-export function findBackfillCandidates(db, { limit = 10 } = {}) {
+// T5：v3 检索字段（keywords/perspectives/semantic_note）全缺失的 active 旧记忆，最旧优先。
+// TTL 内已补过的记忆不再入选（模型"宁可留空"时同样记账，否则同一批每轮都会被重补 + 重嵌入）。
+// 额外带出待比较字段，供 runner 判断"是否真的需要写库"。
+export function findBackfillCandidates(db, { limit = 10, now = new Date() } = {}) {
   return db.prepare(`
-    SELECT memory_id, memory_type, subject, judgment, reasoning, tags, created_at FROM memory_fragments
-    WHERE status = 'active' AND (
-      keywords IS NULL OR keywords IN ('', '[]')
-      OR perspectives IS NULL OR perspectives IN ('', '[]')
-      OR semantic_note IS NULL OR semantic_note = ''
+    SELECT mf.memory_id, mf.memory_type, mf.subject, mf.judgment, mf.reasoning, mf.tags, mf.created_at,
+           mf.keywords, mf.perspectives, mf.semantic_note, mf.episodic_note, mf.importance
+    FROM memory_fragments mf
+    WHERE mf.status = 'active' AND (
+      mf.keywords IS NULL OR mf.keywords IN ('', '[]')
+      OR mf.perspectives IS NULL OR mf.perspectives IN ('', '[]')
+      OR mf.semantic_note IS NULL OR mf.semantic_note = ''
     )
-    ORDER BY COALESCE(updated_at, created_at) ASC LIMIT ?
-  `).all(limit);
+      AND NOT EXISTS (
+        SELECT 1 FROM memory_consolidation_marks mcm
+        WHERE mcm.job_type = 'backfill' AND mcm.mark_key = mf.memory_id AND mcm.marked_at >= ?
+      )
+    ORDER BY COALESCE(mf.updated_at, mf.created_at) ASC, mf.id ASC LIMIT ?
+  `).all(markCutoff('backfill', now), limit);
 }
 
 // T5 是否还有存量（调度器据此决定是否续队）
@@ -320,6 +439,7 @@ const LLM_OPTS = { temperature: 0.2, max_tokens: 1500, response_format: { type: 
  */
 export async function runConflictResolutionTask({ clusters, llmBudgetRemaining = 0, deps = {} } = {}) {
   const chatSync = deps.chatSync;
+  const db = deps.db;
   const applyActions = deps.applyMemoryActions || applyMemoryActions;
   let llmCalls = 0;
   let applied = 0;
@@ -347,9 +467,12 @@ ${listing}
       const raw = await chatSync([{ role: 'user', content: prompt }], LLM_OPTS);
       resolutions = parseJsonObject(raw).resolutions || [];
     } catch (error) {
+      // 调用失败不记账：下一轮自然重试（与"模型判定无关"区分开）
       console.warn('[memory-consolidation] T1 LLM failed:', error.message);
       continue;
     }
+    // 记账：本簇已被模型判定过（含"无关"结论）。不记账则同一簇每轮扫描都会重问，永不停止。
+    markConsolidated(db, 'conflict', cluster.memories.map(m => m.memory_id));
     for (const resolution of resolutions.slice(0, 3)) {
       try {
         if (resolution.type === 'conflict' && resolution.outdatedMemoryId && resolution.updatedFact) {
@@ -416,11 +539,13 @@ ${listing}
  */
 export async function runGeneralizationTask({ groups, llmBudgetRemaining = 0, deps = {} } = {}) {
   const chatSync = deps.chatSync;
+  const db = deps.db;
   const insertGeneralized = deps.insertGeneralizedMemory || insertGeneralizedMemory;
   let llmCalls = 0;
   let applied = 0;
+  let skipped = 0;
   for (const group of groups || []) {
-    if (llmCalls >= llmBudgetRemaining) return { llmCalls, applied, done: false };
+    if (llmCalls >= llmBudgetRemaining) return { llmCalls, applied, skipped, done: false };
     const listing = group.members.map((m, index) => {
       const when = m.event_time || m.created_at || '';
       return `${index + 1}. [${when.slice(0, 10)}] ${m.judgment}`;
@@ -443,7 +568,10 @@ ${listing}
       console.warn('[memory-consolidation] T2 LLM failed:', error.message);
       continue;
     }
-    if (!generalization?.judgment) continue;
+    // 记账：无论模型是否归纳出结论，本组都已被判定过。
+    // 若不记账，"归纳不出结论"（prompt 明确允许 {"generalization":null}）的组会每轮重问。
+    markConsolidated(db, 'generalize', [generalizationMarkKey(group)]);
+    if (!generalization?.judgment) { skipped++; continue; }
     try {
       const memoryId = insertGeneralized({
         conversationId: group.conversation_id,
@@ -465,7 +593,7 @@ ${listing}
       console.warn('[memory-consolidation] T2 insert failed:', error.message);
     }
   }
-  return { llmCalls, applied, done: true };
+  return { llmCalls, applied, skipped, done: true };
 }
 
 // ── T4：核心记忆升华 runner（半自动：只产出建议，人工确认后才入画像）──
@@ -506,6 +634,8 @@ ${pendingLines}
       console.warn('[memory-consolidation] T4 LLM failed:', error.message);
       continue;
     }
+    // 记账：本会话已被模型提炼过（含“提不出新建议”）。不记账则同一会话每轮都要重问一遍。
+    markConsolidated(db, 'portrait_suggest', [conversation.conversationId]);
     const accepted = [];
     for (const item of items.slice(0, 3)) {
       const field = item.field === 'preference' ? 'preference' : 'personality';
@@ -532,15 +662,21 @@ ${pendingLines}
 /**
  * 每批 ≤10 条一次 LLM 调用，补齐 keywords/perspectives/semantic_note/importance。
  * 补完置 embedding_state='stale'——index worker 的 stale 兜底会自动重嵌入，无需额外入队。
+ *
+ * 两条硬约束：
+ *   1. 只在字段真的变化时才写库（含 updated_at / stale）——否则模型留空时既刷新了排序用的
+ *      updated_at，又让 index worker 用完全相同的文本重复付费嵌入；
+ *   2. 无论模型是否补出字段都记账，否则这批候选每轮扫描都会被重补 + 重嵌入，永不前进。
  */
 export async function runBackfillTask({ candidates, llmBudgetRemaining = 0, deps = {} } = {}) {
   const chatSync = deps.chatSync;
   const db = deps.db;
   let llmCalls = 0;
   let updated = 0;
+  let skipped = 0;
   const batch = (candidates || []).slice(0, 10);
-  if (batch.length === 0) return { llmCalls: 0, updated: 0, done: true };
-  if (llmBudgetRemaining <= 0) return { llmCalls: 0, updated: 0, done: false };
+  if (batch.length === 0) return { llmCalls: 0, updated: 0, skipped: 0, done: true };
+  if (llmBudgetRemaining <= 0) return { llmCalls: 0, updated: 0, skipped: 0, done: false };
   const listing = batch.map(m => `- ${m.memory_id} [${m.memory_type}|主体:${m.subject}] 判断：${m.judgment}｜依据：${m.reasoning || '无'}｜tags：${m.tags || '[]'}`).join('\n');
   const prompt = `你是记忆表示补全器。下面这些旧记忆缺少 v3 检索字段，请逐条补全：
 
@@ -562,37 +698,63 @@ ${listing}
     items = parseJsonObject(raw).items || [];
   } catch (error) {
     console.warn('[memory-consolidation] T5 LLM failed:', error.message);
-    return { llmCalls, updated: 0, done: false };
+    return { llmCalls, updated: 0, skipped: 0, done: false };
   }
   const byId = new Map(batch.map(m => [m.memory_id, m]));
   for (const item of items) {
     const row = byId.get(item.memoryId);
     if (!row) continue;
-    const keywords = Array.isArray(item.keywords) ? item.keywords.map(String).map(k => k.trim()).filter(Boolean).slice(0, 8) : [];
-    const perspectives = Array.isArray(item.perspectives) ? item.perspectives.map(String).map(k => k.trim()).filter(Boolean).slice(0, 5) : [];
+    const keywords = stringList(item.keywords).slice(0, 8);
+    const perspectives = stringList(item.perspectives).slice(0, 5);
     const semanticNote = String(item.semanticNote || '').trim().slice(0, 400);
     const episodicNote = String(item.episodicNote || '').trim().slice(0, 400);
     const importance = Math.min(5, Math.max(1, Number(item.importance) || 3));
+
+    // 逐字段判定"是否真的需要写"，只写变化项
+    const changes = {};
+    if (keywords.length && JSON.stringify(keywords) !== JSON.stringify(stringList(row.keywords))) {
+      changes.keywords = JSON.stringify(keywords);
+    }
+    if (perspectives.length && JSON.stringify(perspectives) !== JSON.stringify(stringList(row.perspectives))) {
+      changes.perspectives = JSON.stringify(perspectives);
+    }
+    const currentSemantic = String(row.semantic_note || '').trim();
+    if (semanticNote && semanticNote !== currentSemantic) changes.semantic_note = semanticNote;
+    const currentEpisodic = String(row.episodic_note || '').trim();
+    if (episodicNote && episodicNote !== currentEpisodic) changes.episodic_note = episodicNote;
+    if (importance !== (Number(row.importance) || 3)) changes.importance = importance;
+
+    const columns = Object.keys(changes);
+    if (columns.length === 0) { skipped++; continue; }
     db.prepare(`
-      UPDATE memory_fragments SET
-        keywords = CASE WHEN ? != '[]' THEN ? ELSE keywords END,
-        perspectives = CASE WHEN ? != '[]' THEN ? ELSE perspectives END,
-        semantic_note = CASE WHEN ? != '' THEN ? ELSE semantic_note END,
-        episodic_note = CASE WHEN ? != '' THEN ? ELSE episodic_note END,
-        importance = ?, embedding_state = 'stale', updated_at = CURRENT_TIMESTAMP
+      UPDATE memory_fragments
+      SET ${columns.map(column => `${column} = ?`).join(', ')}, embedding_state = 'stale', updated_at = CURRENT_TIMESTAMP
       WHERE memory_id = ? AND status = 'active'
-    `).run(JSON.stringify(keywords), JSON.stringify(keywords), JSON.stringify(perspectives), JSON.stringify(perspectives),
-      semanticNote, semanticNote, episodicNote, episodicNote, importance, row.memory_id);
+    `).run(...columns.map(column => changes[column]), row.memory_id);
     updated++;
   }
-  return { llmCalls, updated, done: true };
+  // 记账：整批都已被模型看过（含模型留空的条数），下一轮换下一批，不再回环
+  markConsolidated(db, 'backfill', batch.map(row => row.memory_id));
+  return { llmCalls, updated, skipped, done: true };
 }
 
-// 便捷组合：T3 全流程（审计聚合 + 衰减归档），调度器直接调用
+function stringList(value) {
+  if (Array.isArray(value)) return value.map(String).map(text => text.trim()).filter(Boolean);
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.map(String).map(text => text.trim()).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+// 便捷组合：T3 全流程（审计聚合 + 衰减归档 + 辅助表保留期清理），调度器直接调用
 export function runDecayTask({ db, now = new Date(), enqueueDelete, enqueueTripleDelete } = {}) {
   const audited = aggregateRetrievalAudits(db, { now });
   const result = decayAndArchiveMemories(db, { now, enqueueDelete, enqueueTripleDelete });
-  return { audited, ...result, done: true, llmCalls: 0 };
+  const pruned = pruneConsolidationArtifacts(db, { now });
+  return { audited, ...result, pruned, done: true, llmCalls: 0 };
 }
 
 // 便捷组合：T6

--- a/agent-core/src/services/memorySearch.js
+++ b/agent-core/src/services/memorySearch.js
@@ -303,13 +303,21 @@ function queryTokens(query) {
   return [...tokens].slice(0, 24);
 }
 
+// 审计里保存的查询文本长度。curation 检索的"查询"是整段 40 条消息的 transcript，
+// 原样落库既让 memory_retrieval_audits 迅速膨胀，也把大段对话原文写进审计表。
+export const AUDIT_QUERY_MAX_LENGTH = 200;
+
+export function auditQueryText(query) {
+  return String(query ?? '').slice(0, AUDIT_QUERY_MAX_LENGTH);
+}
+
 function writeAudit({ conversationIds, query, mode, textCount, vectorCount, entityCount = 0, memoryIds, fallbackReason }) {
   try {
     const conversationScope = conversationIds.length <= 1 ? (conversationIds[0] || null) : JSON.stringify(conversationIds);
     getDb().prepare(`
       INSERT INTO memory_retrieval_audits(conversation_id, query, mode, candidate_sources, memory_ids, fallback_reason)
       VALUES (?, ?, ?, ?, ?, ?)
-    `).run(conversationScope, String(query).slice(0, 1000), mode, JSON.stringify({ text: textCount, vector: vectorCount, entity: entityCount }), JSON.stringify(memoryIds), fallbackReason);
+    `).run(conversationScope, auditQueryText(query), mode, JSON.stringify({ text: textCount, vector: vectorCount, entity: entityCount }), JSON.stringify(memoryIds), fallbackReason);
   } catch (error) {
     console.error('[memorySearch] audit failed:', error.message);
   }

--- a/agent-core/test/activeSearch.test.js
+++ b/agent-core/test/activeSearch.test.js
@@ -224,17 +224,20 @@ test('activeMemorySearch 超时返回空结果并标记 timedOut', async () => {
   assert.ok(elapsedMs < 2000, `resolved too late: ${elapsedMs}ms`);
 });
 
-test('normalizeMemorySettings 兼容旧键 dailyMaxLlmCalls → llmCallsPerRun', () => {
-  // 旧配置文件只有 dailyMaxLlmCalls：读入新键并保留值
+test('normalizeMemorySettings 把旧键 dailyMaxLlmCalls 归位到每日总量 dailyLlmCalls', () => {
+  // 旧键的语义本来就是"每日总量"，此前被误接到"每轮预算"（默认 6 × 每 5 分钟一轮 = 放大 288 倍）
   const legacy = normalizeMemorySettings({ consolidation: { dailyMaxLlmCalls: 9 } });
-  assert.equal(legacy.consolidation.llmCallsPerRun, 9);
+  assert.equal(legacy.consolidation.dailyLlmCalls, 9);
+  assert.equal(legacy.consolidation.llmCallsPerRun, 3);
   // 新旧键并存时新键优先；输出不再包含旧键（下次保存后彻底迁移）
-  const both = normalizeMemorySettings({ consolidation: { dailyMaxLlmCalls: 2, llmCallsPerRun: 4 } });
-  assert.equal(both.consolidation.llmCallsPerRun, 4);
+  const both = normalizeMemorySettings({ consolidation: { dailyMaxLlmCalls: 2, dailyLlmCalls: 20 } });
+  assert.equal(both.consolidation.dailyLlmCalls, 20);
   assert.equal(both.consolidation.dailyMaxLlmCalls, undefined);
-  // 无任何键时取默认 6
+  // 无任何键时取默认：单轮 3 次、每日 60 次、实干间隔 60 分钟
   const fresh = normalizeMemorySettings({});
-  assert.equal(fresh.consolidation.llmCallsPerRun, 6);
+  assert.equal(fresh.consolidation.llmCallsPerRun, 3);
+  assert.equal(fresh.consolidation.dailyLlmCalls, 60);
+  assert.equal(fresh.consolidation.minIntervalMinutes, 60);
 });
 
 test('activeMemorySearch 历史模式：已失效三元组与其 superseded 记忆参与联想并标历史徽标', async () => {

--- a/agent-core/test/consolidation.test.js
+++ b/agent-core/test/consolidation.test.js
@@ -8,8 +8,10 @@ import {
   findBackfillCandidates,
   runConflictResolutionTask, runGeneralizationTask, runPortraitSuggestionTask, runBackfillTask,
   runDecayTask, runTombstoneTask,
+  markConsolidated, listActiveMarks, RECONSOLIDATE_AFTER_DAYS, pruneConsolidationArtifacts,
 } from '../src/services/memory/memoryConsolidation.js';
 import { insertGeneralizedMemory } from '../src/services/memory/memoryRepository.js';
+import { migrateMemoryConsolidationMarks, migrateMemoryConsolidationSettings } from '../src/db/index.js';
 
 // ── 测试库：阶段三涉及的最小表集合 ──
 
@@ -114,6 +116,18 @@ function createDb() {
       attempts INTEGER NOT NULL DEFAULT 0,
       error TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE memory_consolidation_marks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      job_type TEXT NOT NULL,
+      mark_key TEXT NOT NULL,
+      marked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(job_type, mark_key)
+    );
+    CREATE TABLE system_settings (
+      setting_key TEXT PRIMARY KEY,
+      setting_value TEXT,
       updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     );
     CREATE TABLE portrait_suggestions (
@@ -571,5 +585,210 @@ test('findConflictClusters：已消费的旧记忆不中断簇发现（continue 
   assert.equal(clusters.length, 2);
   const clusterIds = clusters.map(cluster => cluster.memories.map(m => m.memory_id).sort().join(',')).sort();
   assert.deepEqual(clusterIds, ['mem_c1,mem_o1', 'mem_c2,mem_o2']);
+  db.close();
+});
+
+// ── 整理记账：同一批候选不得被反复送进 LLM（历史缺陷：每 5 分钟重问一次，永不停止）──
+
+function insertConflictPair(db) {
+  insertFragment(db, { memoryId: 'mem_new', judgment: '她今天点了香菜牛肉', createdAt: daysAgo(0) });
+  insertFragment(db, { memoryId: 'mem_old', judgment: '她讨厌香菜', createdAt: daysAgo(3) });
+  linkEntity(db, 'mem_new', '香菜');
+  linkEntity(db, 'mem_old', '香菜');
+}
+
+test('T1 记账：模型判定"无关"后同一簇不再重复入选（连续 5 轮扫描只花 1 次 LLM）', async () => {
+  const db = createDb();
+  insertConflictPair(db);
+  let llmCalls = 0;
+  const deps = {
+    db,
+    chatSync: async () => { llmCalls++; return JSON.stringify({ resolutions: [] }); },
+    applyMemoryActions: () => ({}),
+  };
+
+  // 第一轮：发现簇 → 1 次 LLM → 模型说"无关"（无任何内容写入）→ 记账
+  const first = await runConflictResolutionTask({ clusters: findConflictClusters(db), llmBudgetRemaining: 6, deps });
+  assert.equal(first.llmCalls, 1);
+  assert.equal(first.applied, 0);
+  assert.deepEqual(listActiveMarks(db, 'conflict').sort(), ['mem_new', 'mem_old']);
+
+  // 后续 4 轮扫描（daemon 每 5 分钟一轮）：候选为空 → 0 次 LLM
+  for (let round = 0; round < 4; round++) {
+    const next = await runConflictResolutionTask({ clusters: findConflictClusters(db), llmBudgetRemaining: 6, deps });
+    assert.equal(next.llmCalls, 0, `第 ${round + 2} 轮不应再调 LLM`);
+  }
+  assert.equal(llmCalls, 1, '修复前这里是 5 次');
+  db.close();
+});
+
+test('T1 记账带 TTL：到期后同一条记忆可以重新整理', () => {
+  const db = createDb();
+  insertConflictPair(db);
+  markConsolidated(db, 'conflict', ['mem_new', 'mem_old']);
+  assert.equal(findConflictClusters(db).length, 0);
+  // 记账时间推到 TTL 之前 → 重新成为候选
+  const expired = new Date(Date.now() - (RECONSOLIDATE_AFTER_DAYS.conflict + 1) * 86400000).toISOString().slice(0, 19).replace('T', ' ');
+  db.prepare(`UPDATE memory_consolidation_marks SET marked_at = ?`).run(expired);
+  assert.equal(findConflictClusters(db).length, 1);
+  assert.equal(listActiveMarks(db, 'conflict').length, 0);
+  db.close();
+});
+
+test('LLM 调用失败不记账：下一轮仍会重试（不把失败当"已处理"）', async () => {
+  const db = createDb();
+  insertConflictPair(db);
+  const deps = {
+    db,
+    chatSync: async () => { throw new Error('boom'); },
+    applyMemoryActions: () => ({}),
+  };
+  const result = await runConflictResolutionTask({ clusters: findConflictClusters(db), llmBudgetRemaining: 6, deps });
+  assert.equal(result.llmCalls, 1);
+  assert.equal(listActiveMarks(db, 'conflict').length, 0);
+  assert.equal(findConflictClusters(db).length, 1);
+  db.close();
+});
+
+test('T2 记账：模型输出 generalization:null 后该组不再重复入选', async () => {
+  const db = createDb();
+  for (const [id, days] of [['mem_ev0', 30], ['mem_ev1', 18], ['mem_ev2', 5]]) {
+    insertFragment(db, { memoryId: id, type: 'event', judgment: `情景记录${id}`, eventTime: daysAgo(days), conversationId: 'char_1' });
+    linkEntity(db, id, '感冒');
+  }
+  let llmCalls = 0;
+  const deps = {
+    db,
+    chatSync: async () => { llmCalls++; return JSON.stringify({ generalization: null }); },
+    insertGeneralizedMemory: () => 'x',
+  };
+  const first = await runGeneralizationTask({ groups: findGeneralizationGroups(db), llmBudgetRemaining: 6, deps });
+  assert.equal(first.llmCalls, 1);
+  assert.equal(first.applied, 0);
+  assert.equal(first.skipped, 1);
+  // 修复前这里仍是 1（组永不消失，每轮重问）
+  assert.equal(findGeneralizationGroups(db).length, 0);
+  const second = await runGeneralizationTask({ groups: findGeneralizationGroups(db), llmBudgetRemaining: 6, deps });
+  assert.equal(second.llmCalls, 0);
+  assert.equal(llmCalls, 1);
+  db.close();
+});
+
+test('T4 记账：模型提不出新建议时同一会话不再每轮重问', async () => {
+  const db = createDb();
+  insertFragment(db, { memoryId: 'mem_core', type: 'knowledge', importance: 5, conversationId: 'char_7' });
+  let llmCalls = 0;
+  const deps = { db, chatSync: async () => { llmCalls++; return JSON.stringify({ suggestions: [] }); } };
+  const first = await runPortraitSuggestionTask({ conversations: findPortraitSuggestionConversations(db), llmBudgetRemaining: 6, deps });
+  assert.equal(first.llmCalls, 1);
+  assert.equal(findPortraitSuggestionConversations(db).length, 0);
+  const second = await runPortraitSuggestionTask({ conversations: findPortraitSuggestionConversations(db), llmBudgetRemaining: 6, deps });
+  assert.equal(second.llmCalls, 0);
+  assert.equal(llmCalls, 1);
+  db.close();
+});
+
+test('T5 记账 + 条件写入：模型留空时不写库、不刷 updated_at、不置 stale，且不再回环', async () => {
+  const db = createDb();
+  insertFragment(db, { memoryId: 'mem_legacy', judgment: '用户养了一只猫', keywords: null, createdAt: daysAgo(30) });
+  const before = db.prepare(`SELECT updated_at, embedding_state FROM memory_fragments WHERE memory_id = 'mem_legacy'`).get();
+  const deps = {
+    db,
+    chatSync: async () => JSON.stringify({
+      items: [{ memoryId: 'mem_legacy', keywords: [], perspectives: [], semanticNote: '', episodicNote: '', importance: 3 }],
+    }),
+  };
+  const result = await runBackfillTask({ candidates: findBackfillCandidates(db), llmBudgetRemaining: 6, deps });
+  assert.equal(result.llmCalls, 1);
+  assert.equal(result.updated, 0);
+  assert.equal(result.skipped, 1);
+  const after = db.prepare(`SELECT updated_at, embedding_state FROM memory_fragments WHERE memory_id = 'mem_legacy'`).get();
+  assert.equal(after.updated_at, before.updated_at, '无变化不应刷新 updated_at（会污染检索排序）');
+  assert.equal(after.embedding_state, before.embedding_state, '无变化不应置 stale（会重复付费重嵌入同一文本）');
+  assert.equal(findBackfillCandidates(db).length, 0, '已问过模型的不再回环');
+  db.close();
+});
+
+// ── 维护清理 ──
+
+test('migrateMemoryConsolidationMarks：建表幂等并补齐维护索引', () => {
+  const db = createDb();
+  migrateMemoryConsolidationMarks(db);
+  migrateMemoryConsolidationMarks(db); // 幂等
+  const table = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_consolidation_marks'`).get();
+  assert.ok(table, '记账表应存在');
+  const indexes = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'index' AND name LIKE 'idx_memory_%'`).all().map(row => row.name);
+  assert.ok(indexes.includes('idx_memory_consolidation_jobs_type'));
+  assert.ok(indexes.includes('idx_memory_retrieval_audits_created'));
+  db.close();
+});
+
+test('pruneConsolidationArtifacts：按保留期清理审计/已终结任务/过期记账，不碰 pending', () => {  const db = createDb();
+  db.prepare(`INSERT INTO memory_retrieval_audits(query, mode, created_at) VALUES ('old', 'passive', ?)`).run(daysAgo(120));
+  db.prepare(`INSERT INTO memory_retrieval_audits(query, mode, created_at) VALUES ('new', 'passive', ?)`).run(daysAgo(1));
+  db.prepare(`INSERT INTO memory_consolidation_jobs(job_type, status, updated_at) VALUES ('decay', 'completed', ?)`).run(daysAgo(30));
+  db.prepare(`INSERT INTO memory_consolidation_jobs(job_type, status, updated_at) VALUES ('decay', 'pending', ?)`).run(daysAgo(30));
+  markConsolidated(db, 'backfill', ['mem_gone']);
+  db.prepare(`UPDATE memory_consolidation_marks SET marked_at = ?`).run(daysAgo(400));
+
+  const pruned = pruneConsolidationArtifacts(db, {});
+  assert.equal(pruned.audits, 1);
+  assert.equal(pruned.jobs, 1);
+  assert.equal(pruned.marks, 1);
+  assert.equal(db.prepare(`SELECT COUNT(*) AS c FROM memory_consolidation_jobs`).get().c, 1, 'pending 任务永不清理');
+  assert.equal(db.prepare(`SELECT COUNT(*) AS c FROM memory_retrieval_audits`).get().c, 1);
+  db.close();
+});
+
+test('decayAndArchiveMemories：强度未变化时不重复写库', () => {
+  const db = createDb();
+  insertFragment(db, { memoryId: 'mem_stable', importance: 5, lastReinforcedAt: daysAgo(1), createdAt: daysAgo(1) });
+  const first = decayAndArchiveMemories(db, {});
+  const second = decayAndArchiveMemories(db, {});
+  assert.equal(first.scanned, 1);
+  assert.equal(first.strengthened, 1, '首次写入强度');
+  assert.equal(second.strengthened, 0, '同一天重跑不应再写（避免全表无谓写放大）');
+  db.close();
+});
+
+// ── 配置显式化迁移 ──
+
+test('migrateMemoryConsolidationSettings：补全 consolidation 且其余配置逐字保留', () => {
+  const db = createDb();
+  assert.equal(migrateMemoryConsolidationSettings(db).skipped, 'no-settings', '全新库由种子行覆盖');
+  db.prepare(`INSERT INTO system_settings(setting_key, setting_value) VALUES ('memory_settings', ?)`)
+    .run(JSON.stringify({ enabled: true, topK: 7, embedding: { enabled: false } }));
+
+  const first = migrateMemoryConsolidationSettings(db);
+  assert.equal(first.updated, true);
+  assert.deepEqual(first.consolidation, { enabled: true, idleDelayMinutes: 30, minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60, portraitSuggest: true });
+  const stored = JSON.parse(db.prepare(`SELECT setting_value FROM system_settings WHERE setting_key = 'memory_settings'`).get().setting_value);
+  assert.equal(stored.topK, 7, '其余配置不得被动到');
+  assert.equal(stored.embedding.enabled, false);
+  assert.equal(migrateMemoryConsolidationSettings(db).skipped, 'up-to-date', '幂等');
+  db.close();
+});
+
+test('migrateMemoryConsolidationSettings：旧键 dailyMaxLlmCalls 归位且不覆盖用户已存值', () => {
+  const db = createDb();
+  db.prepare(`INSERT INTO system_settings(setting_key, setting_value) VALUES ('memory_settings', ?)`)
+    .run(JSON.stringify({ consolidation: { enabled: false, idleDelayMinutes: 120, dailyMaxLlmCalls: 9 } }));
+
+  const result = migrateMemoryConsolidationSettings(db);
+  assert.equal(result.updated, true);
+  assert.deepEqual(result.consolidation, { enabled: false, idleDelayMinutes: 120, minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 9, portraitSuggest: true });
+  assert.equal(result.consolidation.dailyMaxLlmCalls, undefined, '旧键被归位而非保留');
+  db.close();
+});
+
+test('migrateMemoryConsolidationSettings：用户显式关掉的 T4 不被迁移改回开启', () => {
+  const db = createDb();
+  db.prepare(`INSERT INTO system_settings(setting_key, setting_value) VALUES ('memory_settings', ?)`)
+    .run(JSON.stringify({ consolidation: { portraitSuggest: false } }));
+
+  const result = migrateMemoryConsolidationSettings(db);
+  assert.equal(result.updated, true);
+  assert.equal(result.consolidation.portraitSuggest, false, '显式 false 必须逐字保留（白名单漏键会把它悄悄改回 true）');
+  assert.equal(migrateMemoryConsolidationSettings(db).skipped, 'up-to-date', '幂等');
   db.close();
 });

--- a/agent-core/test/consolidationScheduler.test.js
+++ b/agent-core/test/consolidationScheduler.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateRunGates, readDailyUsage, shanghaiDateKey } from '../src/services/memory/consolidationScheduler.js';
+
+const NOW = new Date('2026-09-10T12:00:00Z');
+const cfg = { minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60 };
+
+function isoMinutesAgo(minutes) {
+  return new Date(NOW.getTime() - minutes * 60000).toISOString();
+}
+
+test('evaluateRunGates：空闲且距上次实干够久 → 放行', () => {
+  const gate = evaluateRunGates({ state: { lastWorkedAt: isoMinutesAgo(90) }, cfg, idle: true, now: NOW.getTime() });
+  assert.deepEqual(gate, { run: true });
+});
+
+test('evaluateRunGates：空闲但未到最小间隔 → min-interval（修复前会每 5 分钟跑一整轮）', () => {
+  // 用户已离开（idle=true），上一次实干在 10 分钟前：旧逻辑会立刻再跑一轮
+  const gate = evaluateRunGates({ state: { lastWorkedAt: isoMinutesAgo(10) }, cfg, idle: true, now: NOW.getTime() });
+  assert.deepEqual(gate, { run: false, skipped: 'min-interval' });
+});
+
+test('evaluateRunGates：不空闲且距上次实干 < 22h → not-idle；≥ 22h → 兜底放行', () => {
+  const recent = evaluateRunGates({ state: { lastWorkedAt: isoMinutesAgo(120) }, cfg, idle: false, now: NOW.getTime() });
+  assert.deepEqual(recent, { run: false, skipped: 'not-idle' });
+  const fallback = evaluateRunGates({ state: { lastWorkedAt: isoMinutesAgo(23 * 60) }, cfg, idle: false, now: NOW.getTime() });
+  assert.deepEqual(fallback, { run: true });
+});
+
+test('evaluateRunGates：空转轮不再刷新兜底锚点（lastFinishedAt 不参与判定）', () => {
+  // 只有 lastFinishedAt 被每轮刷新、lastWorkedAt 是很久以前 → 22h 兜底应当生效
+  const gate = evaluateRunGates({
+    state: { lastFinishedAt: isoMinutesAgo(1), lastWorkedAt: isoMinutesAgo(23 * 60) },
+    cfg,
+    idle: false,
+    now: NOW.getTime(),
+  });
+  assert.deepEqual(gate, { run: true });
+});
+
+test('evaluateRunGates：上一轮空手而归 → scan-backoff', () => {
+  const gate = evaluateRunGates({
+    state: { lastWorkedAt: isoMinutesAgo(600), lastEmptyScanAt: isoMinutesAgo(5) },
+    cfg,
+    idle: true,
+    now: NOW.getTime(),
+  });
+  assert.deepEqual(gate, { run: false, skipped: 'scan-backoff' });
+  const later = evaluateRunGates({
+    state: { lastWorkedAt: isoMinutesAgo(600), lastEmptyScanAt: isoMinutesAgo(31) },
+    cfg,
+    idle: true,
+    now: NOW.getTime(),
+  });
+  assert.deepEqual(later, { run: true });
+});
+
+test('readDailyUsage：跨上海日期归零，同日内累计', () => {
+  const date = shanghaiDateKey(NOW);
+  assert.equal(readDailyUsage({ daily: { date, used: 17 } }, NOW).used, 17);
+  assert.equal(readDailyUsage({ daily: { date: '2026-09-09', used: 17 } }, NOW).used, 0);
+  assert.equal(readDailyUsage({}, NOW).used, 0);
+});

--- a/docs/memory-upgrade-plan.md
+++ b/docs/memory-upgrade-plan.md
@@ -369,8 +369,9 @@ memoryLines.push(`${i + 1}. [${label}] ${text}`);
 
 新文件 `services/memory/consolidationScheduler.js`，模式对齐 `proactiveChatScheduler.js`：
 
-- **触发**：空闲判定（无活跃 SSE 流 且 距最后一条消息 ≥ `idleDelayMinutes`，默认 30 分钟）或每日一次兜底；可选产品化——结合角色 `schedule_templates` 作息，在角色"睡觉"时段执行（"她睡着后在整理今天的记忆"）。
-- **预算**：单次运行 LLM 调用 ≤ `dailyMaxLlmCalls`（默认 6）、总 token 上限；全部走 `chatSync` + `llmConcurrency` 正常排队，label 统一 `记忆整理`。
+- **触发**：空闲判定（无活跃前台聊天流 且 距最后一条消息 ≥ `idleDelayMinutes`，默认 30 分钟）或每日一次兜底；可选产品化——结合角色 `schedule_templates` 作息，在角色"睡觉"时段执行（"她睡着后在整理今天的记忆"）。
+  > ⚠️ 实施修订（2026-09-10）：仅靠空闲判定等于"用户离开后每 5 分钟一满轮"，且候选不做消费记账会被无限重问。实际实现另加 `minIntervalMinutes`（两次实干最小间隔）、`dailyLlmCalls`（每日总量）、空转退避与 `memory_consolidation_marks` 记账，详见 [memory-upgrade-progress.md](memory-upgrade-progress.md) 的"记忆系统空转 / token 审查修复"一节。
+- **预算**：单次运行 LLM 调用 ≤ `llmCallsPerRun`（默认 3）、每日总量 ≤ `dailyLlmCalls`（默认 60）、总 token 上限；全部走 `chatSync` + `llmConcurrency` 正常排队，label 统一 `记忆整理`。
 - **任务表**：`memory_consolidation_jobs`，启动时 `processing→pending` 恢复（模式同 index worker L432），`attempts` ≥3 进 failed 不再自动重试。
 - **feature flag**：`memory_settings.consolidation.enabled`。
 
@@ -451,7 +452,7 @@ archived 不进任何检索通道，管理界面可查可恢复（恢复即 stat
 v3:            { enabled: true },                       // 阶段一：新表示与实体信号
 activeSearch:  { enabled: false, timeoutMs: 4000 },     // 阶段二：@memory 主动回想
 consolidation: { enabled: true, idleDelayMinutes: 30,   // 阶段三：整理 daemon
-                 dailyMaxLlmCalls: 6 },
+                 minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60 },
 contextBudget: { enabled: false, dynamicTokens: 8000 }, // 阶段四：上下文预算
 ```
 

--- a/docs/memory-upgrade-progress.md
+++ b/docs/memory-upgrade-progress.md
@@ -111,9 +111,9 @@
 ### 阶段三落地内容
 
 **调度器**（新建 `services/memory/consolidationScheduler.js`）：
-- 每 5 分钟扫描；空闲判定 = 无活跃聊天流（新增 `services/chatActivity.js` 计数器，chat.js 流式路由以 `res.on('close')` 恰好注销一次）且距最后一条消息 ≥ `idleDelayMinutes`；距上次运行 >22h 兜底；聊天进行中永不触发 LLM
-- 预算：单轮 LLM 调用 ≤ `llmCallsPerRun`（0 = 禁 LLM 任务，SQL 任务照跑；旧键 `dailyMaxLlmCalls` 兼容读取，改名修正"实为每轮预算而非每日"的语义）；预算耗尽时任务退回 pending 下轮续跑，未完成的 LLM 任务自动补后续任务
-- 任务表 `memory_consolidation_jobs`：候选发现入队（同类型去重）、SQL 任务先于 LLM 任务领取、启动/每轮 processing→pending 恢复、attempts≥3 落 failed；运行状态写 `system_settings('memory_consolidation_state')`
+- 每 5 分钟扫描；空闲判定 = 无活跃前台聊天流（新增 `services/chatActivity.js` 计数器，chat.js 流式路由以 `res.on('close')` 恰好注销一次；群聊 SSE 与冷场续聊同样登记）且距最后一条消息 ≥ `idleDelayMinutes`；距上次**真正干过活** >22h 兜底；聊天进行中永不触发 LLM
+- 预算三层：单轮 LLM 调用 ≤ `llmCallsPerRun`、每日 ≤ `dailyLlmCalls`（持久化、按上海日期归零）、两次实干之间 ≥ `minIntervalMinutes`；预算耗尽时任务退回 pending 下轮续跑，未完成的 LLM 任务自动补后续任务
+- 任务表 `memory_consolidation_jobs`：候选发现入队（同类型去重）、SQL 任务先于 LLM 任务领取、同优先级按"该类型上次完成时间"轮转（防 T1/T2 吃满预算饿死 T4/T5）、启动/每轮 processing→pending 恢复、attempts≥3 落 failed；运行状态写 `system_settings('memory_consolidation_state')`（含 `daily` 用量、`lastWorkedAt`、`lastEmptyScanAt`）
 
 **任务实现**（新建 `services/memory/memoryConsolidation.js`，全部依赖可注入）：
 - T1 冲突消解：近 7 天新记忆按共享实体聚类 → LLM 矛盾→`applyMemoryActions('update')` 双时态失效 / 重复→merge
@@ -124,7 +124,7 @@
 - T6 墓碑扫描：碎片看"存在晚于状态变更的 completed delete 任务"幂等跳过；三元组入队后置 embedding_state=disabled
 - v3 总开关关闭时 T2/T4/T5 自动跳过（`taskEnabledByV3`）
 
-**配置与 UI**：`memory_settings.consolidation={enabled:true, idleDelayMinutes:30, llmCallsPerRun:6}`；MemorySettingsView 新增"记忆整理（睡眠期）"卡片（开关+空闲分钟+预算+"立即整理一次"按钮）
+**配置与 UI**：`memory_settings.consolidation={enabled:true, idleDelayMinutes:30, minIntervalMinutes:60, llmCallsPerRun:3, dailyLlmCalls:60}`；MemorySettingsView"记忆整理（睡眠期）"卡片（开关+空闲分钟+最小间隔+单轮上限+每日总量+"立即整理一次"按钮，并实时显示最坏每天调用次数）
 
 ### 阶段四落地内容
 
@@ -153,7 +153,7 @@
 阶段二~四完成后做了逐文件审查（发现 2 中 + 4 低 + 1 风格 + 2 信息级），全部修复：
 
 - **【中】T2 泛化反复升华**：同一实体组每轮 daemon 都重新生成泛化记忆（content_hash 各异无法去重兜住）→ `findGeneralizationGroups` 增加 `hasLivingGeneralization` 检查，组内已有存活泛化后代（relation_meta=generalize 且子记忆 active）即跳过；后代被 rollback 后组自动重新成为候选。
-- **【中】配置键正名**：`dailyMaxLlmCalls` 实为"每轮整理"预算（每 5 分钟一轮、每轮重置）而非每日总量 → 改名 `llmCallsPerRun`，`normalizeMemorySettings` 兼容旧键（新键优先、保存后旧键自然淘汰），前端表单/payload 同步。
+- **【中】配置键正名**：`dailyMaxLlmCalls` 实为"每轮整理"预算（每 5 分钟一轮、每轮重置）而非每日总量 → 改名 `llmCallsPerRun`，`normalizeMemorySettings` 兼容旧键（新键优先、保存后旧键自然淘汰），前端表单/payload 同步。**（2026-09-10 追记：这次改名只改了名字没改间隔与数值，实际把预算放大了 288 倍；已改为 `dailyMaxLlmCalls → dailyLlmCalls`（每日总量）+ 独立 `minIntervalMinutes` 闸门，见下方审查修复一节。）**
 - **【低】@memory 二次续写失败兜底**：`chat.js` 续写调用加 try-catch，无任何内容时补一条角色化短文本（"……抱歉，刚刚走了一下神"）走正常落库；已有部分内容则保留半截回复——不再让用户面对沉默。
 - **【低】T1 替代记忆 v2 形态**：决议 prompt 增加可选 keywords/semanticNote 字段并透传 `applyMemoryActions`，替代记忆直接完整入库，不必再等 T5 回填。
 - **【低】findConflictClusters 提前中断**：遍历到已消费旧记忆时 `break` 会跳过后面未处理的簇代表 → 拆分条件为 limit 用 `break`、已消费用 `continue`。
@@ -161,6 +161,33 @@
 - **【信息】历史模式三元组联想**：时态查询（"以前/曾经…"）时已失效三元组与其 superseded 记忆也参与联想并标历史徽标——否则旧事实演化后"她以前讨厌什么"联想不到任何东西；现行模式维持双时态现行过滤。
 - **【风格】** `stores/chat.js` 新增行缩进对齐。
 - 新增 5 个测试用例（改名兼容、T2 去重含后代失效恢复、簇发现 continue 场景、历史/现行模式三元组联想），全量 82/82 通过。
+
+---
+
+### 记忆系统空转 / token 审查修复（2026-09-10）
+
+背景：对整理 daemon 做专项审查，实测确认"同一批候选被无限重复送进 LLM"。根因是候选发现只按时间窗/状态筛选，而模型给出"无关 / 归纳不出结论 / 补不出字段"这类**不产生任何内容写入**的结论时，候选不会消失；叠加"空闲判定在用户离开后恒为真"，等于每 5 分钟把同一批候选重问一次，模型调用量最坏 6 次/轮 × 288 轮/天。
+
+**实测证据**（内存库 + 仓库自身函数，确定性复现；修复前行为）：
+- T1：5 轮扫描 → 5 次 LLM、0 次落地，记忆状态零变化
+- T2：模型返回 `generalization:null` → 组每轮都重新入选，5 轮 5 次 LLM
+- T4：同一会话每轮都被重新送进 LLM（无 status/时间/已处理过滤）
+- T5：模型留空时 `updated_at` 被刷新、`embedding_state` 置 stale（用**完全相同的文本**重复付费重嵌入），候选下一轮仍在
+
+**修复**：
+
+1. **候选消费记账（新增表 `memory_consolidation_marks`）**：`(job_type, mark_key, marked_at)` + TTL（conflict 7 / generalize 30 / portrait_suggest 14 / backfill 30 天）。四个 runner 在 **LLM 成功返回后**无条件记账（含"无关/无结论/留空"），调用抛错则不记账、下轮重试。四个候选发现函数按记账过滤。没有这道记账，daemon 的空转是无限的。
+2. **预算语义归位**：`dailyMaxLlmCalls → dailyLlmCalls`（每日总量，默认 60，持久化在 `state.daily`、按上海日期归零）；`llmCallsPerRun` 默认 6 → 3；新增 `minIntervalMinutes`（默认 60）限制两次**实干**的间隔；空转轮退避 30 分钟（`lastEmptyScanAt`）；22h 兜底改锚在 `lastWorkedAt`（原先空转轮也刷 `lastFinishedAt`，兜底线永不触发）。新增迁移 `migrateMemoryConsolidationSettings`：老库启动时幂等把整个 consolidation 配置块显式写回 `memory_settings`（只补缺失键、不覆盖用户值，旧键归位后删除），避免"库里没有该块、实际生效值只能靠默认值猜"。
+3. **任务饥饿修复**：`claimNextJob` 同优先级内按"该类型上次完成时间"轮转，替代 `id ASC`——原先 T1(≤4)+T2(≤2) 可稳定吃满 6 次预算，T4/T5 永久 pending。
+4. **T5 条件写入**：逐字段比对，只在真的变化时写库并置 stale；模型留空 → `skipped`，不刷 `updated_at`（避免污染检索排序）、不触发重嵌入。
+5. **T3 免空写 + 维护清理**：`strength` 未变化不写（`strength IS NOT ?`）；语句移出循环；`pruneConsolidationArtifacts` 随 T3 清理审计（90 天）/已终结任务（7 天）/过期记账（180 天）；`memory_retrieval_audits` 补 `created_at` 索引，审计 query 从 1000 字截到 200 字（curation 的"查询"是整段 40 条对话，原先整段落库）。
+6. **前台聊天流覆盖**：群聊 SSE（`/:id/chat`）与冷场续聊（`/:id/nudge`）登记进 `chatActivity`——原先只有 1v1 聊天让路，群聊期间 daemon 照常发 LLM。
+7. **内置第三方服务可控**：新增 `embedding.useBuiltin` / `reranker.useBuiltin`（默认 true，行为不变；关闭后彻底不碰随包内置服务，改走本地模型）；失败计数改为内存缓存（原先每次嵌入/重排都读一次 `system_settings`，每轮至少 2 次额外 DB 往返）。
+8. **画像去重批量嵌入**：一次提取只做一次 `embedBatch`（全部待写入特征 + 相关维度全部已有画像），字面重复直接丢弃；原先每条新特征都重新嵌入全部已有画像（O(N) 次重复调用）。同时删除从未被调用的死代码 `deduplicatePortraits`。
+9. **UI 合规与可观测**：MemorySettingsView 剩余裸 `input[type=checkbox]` / 裸 number input 全部改为 `linshe-switch` / `linshe-input`；新增最小间隔与每日总量字段并实时显示"最坏每天调用次数"；手动触发失败原因分档提示。
+
+**验证**：新增 15 个回归用例（`test/consolidation.test.js` 9 例：T1 连续 5 轮只花 1 次 LLM、TTL 到期可重新整理、LLM 失败不记账、T2 null 不重问、T4 不重问、T5 留空不写库不回环、迁移幂等、保留期清理不碰 pending、强度未变不写库；`test/consolidationScheduler.test.js` 6 例：放行/min-interval/not-idle 与 22h 兜底/空转锚点不刷兜底/空扫退避/跨日额度归零），本机 `node --test` 全量 **81/81** 通过。
+（受限沙箱下 `node --test` 默认按文件 spawn 子进程会报 `spawn EPERM`，用 `--test-isolation=none` 可同进程运行。）
 
 ---
 
@@ -173,6 +200,6 @@
 ## 快速上手（新会话接续开发）
 
 1. 读 `docs/memory-upgrade-plan.md`（设计）+ 本文件（进度）+ CLAUDE.md 记忆系统章节（模块地图）
-2. 跑测试确认基线：`cd agent-core && ../runtime/nodejs/node.exe --test "test/*.test.js" "src/services/*.test.js"`（应 82/82）
+2. 跑测试确认基线：`cd agent-core && ../runtime/nodejs/node.exe --test "test/*.test.js" "src/services/*.test.js"`（应 81/81；受限沙箱里默认按文件 spawn 子进程会 `spawn EPERM`，加 `--test-isolation=none` 同进程跑）
 3. 记忆系统四阶段已全部落地，`memory/` 目录阅读顺序：memoryConfig（四组开关）→ memoryRepository（落库+索引队列）→ memorySearch/chatMemoryRecall（被动召回）→ activeSearch（@memory 主动回想）→ memoryConsolidation + consolidationScheduler（整理 daemon）→ contextAssembler.applyContextBudget（上下文预算）
 4. 遇 Mimosa 钩子误报见上方"已知注意事项"；UI 改动先读 `docs/design-system.md`

--- a/web-ui/src/views/MemorySettingsView.vue
+++ b/web-ui/src/views/MemorySettingsView.vue
@@ -105,11 +105,11 @@
       <section class="card" style="margin-top: 16px;">
         <div class="section-title">
           <div><h3>主动回想</h3><p>角色会在需要时主动检索自己的记忆（可能略微增加回复等待）。</p></div>
-          <label class="switch"><input v-model="form.activeSearch.enabled" type="checkbox" aria-label="主动回想"><span></span></label>
+          <linshe-switch v-model="form.activeSearch.enabled" aria-label="主动回想" />
         </div>
         <CollapseTransition :show="form.activeSearch.enabled">
           <div class="collapse-body">
-            <label>回想最长等待时间（毫秒）<input v-model.number="form.activeSearch.timeoutMs" type="number" min="1000" max="30000"></label>
+            <label>回想最长等待时间（毫秒）<linshe-input v-model.number="form.activeSearch.timeoutMs" type="number" min="1000" max="30000" /></label>
             <p class="disabled-note">开启后，角色遇到“你应该记得”的话题时会自主发起一次记忆检索，结果只用于当轮回复。</p>
           </div>
         </CollapseTransition>
@@ -118,16 +118,22 @@
       <section class="card" style="margin-top: 16px;">
         <div class="section-title">
           <div><h3>记忆整理（睡眠期）</h3><p>用户不聊天时，后台自动整理记忆：冲突消解、泛化归纳、强度衰减归档、画像建议。</p></div>
-          <label class="switch"><input v-model="form.consolidation.enabled" type="checkbox" aria-label="记忆整理"><span></span></label>
+          <linshe-switch v-model="form.consolidation.enabled" aria-label="记忆整理" />
         </div>
         <CollapseTransition :show="form.consolidation.enabled">
           <div class="collapse-body">
-            <label>空闲判定（分钟，距最后一条消息）<input v-model.number="form.consolidation.idleDelayMinutes" type="number" min="5" max="720"></label>
-            <label>单轮整理模型调用上限<input v-model.number="form.consolidation.llmCallsPerRun" type="number" min="0" max="30"></label>
+            <div class="two-col">
+              <label>空闲判定（分钟，距最后一条消息）<linshe-input v-model.number="form.consolidation.idleDelayMinutes" type="number" min="5" max="720" /></label>
+              <label>两次整理最小间隔（分钟）<linshe-input v-model.number="form.consolidation.minIntervalMinutes" type="number" min="0" max="1440" /></label>
+            </div>
+            <div class="two-col">
+              <label>单轮模型调用上限<linshe-input v-model.number="form.consolidation.llmCallsPerRun" type="number" min="0" max="30" /></label>
+              <label>每日模型调用总量<linshe-input v-model.number="form.consolidation.dailyLlmCalls" type="number" min="0" max="2000" /></label>
+            </div>
             <div style="margin-top: 8px;">
               <linshe-button variant="ghost" size="sm" :disabled="consolidating" @click="triggerConsolidation">{{ consolidating ? '整理中…' : '立即整理一次' }}</linshe-button>
             </div>
-            <p class="disabled-note">整理永远避开聊天进行中；模型调用预算用尽时，剩余任务留到下轮继续。</p>
+            <p class="disabled-note">当前设置下每天最多 {{ consolidationDailyWorstCase }} 次模型调用（空闲判定、最小间隔、每日总量三重限制，实际只会更少）。同一批记忆整理过后会记账，模型判定“无关”也不会反复重问；整理永远避开聊天进行中，预算用尽时剩余任务留到下轮继续。</p>
           </div>
         </CollapseTransition>
       </section>
@@ -135,11 +141,11 @@
       <section class="card" style="margin-top: 16px;">
         <div class="section-title">
           <div><h3>上下文预算</h3><p>限制随每轮消息注入的动态上下文总量，超出时按“历史减半 → 记忆裁剪 → 整块丢弃”逐级降级。</p></div>
-          <label class="switch"><input v-model="form.contextBudget.enabled" type="checkbox" aria-label="上下文预算"><span></span></label>
+          <linshe-switch v-model="form.contextBudget.enabled" aria-label="上下文预算" />
         </div>
         <CollapseTransition :show="form.contextBudget.enabled">
           <div class="collapse-body">
-            <label>动态上下文 token 预算<input v-model.number="form.contextBudget.dynamicTokens" type="number" min="2000" max="100000"></label>
+            <label>动态上下文 token 预算<linshe-input v-model.number="form.contextBudget.dynamicTokens" type="number" min="2000" max="100000" /></label>
             <p class="disabled-note">稳定人设部分不参与预算；降级过程会记录在服务端日志，不会静默截断。</p>
           </div>
         </CollapseTransition>
@@ -460,7 +466,7 @@ const consolidating = ref(false)
 const form = reactive({
   enabled: true, topK: 7, textCandidates: 24, vectorCandidates: 24, recordUnengagedEvents: true,
   activeSearch: { enabled: false, timeoutMs: 4000 },
-  consolidation: { enabled: true, idleDelayMinutes: 30, llmCallsPerRun: 6 },
+  consolidation: { enabled: true, idleDelayMinutes: 30, minIntervalMinutes: 60, llmCallsPerRun: 3, dailyLlmCalls: 60 },
   contextBudget: { enabled: false, dynamicTokens: 8000 },
   embedding: { enabled: false, provider: 'custom', baseURL: '', apiKey: '', model: '', dimensions: null, headers: {}, timeoutMs: 8000, hasApiKey: false },
   reranker: { enabled: false, provider: 'custom', baseURL: '', apiKey: '', model: '', topN: 7, headers: {}, timeoutMs: 8000, hasApiKey: false },
@@ -472,6 +478,13 @@ const indexedCount = computed(() => sumRows(row => row.status === 'active' && ro
 const failedCount = computed(() => sumRows(row => row.status === 'active' && row.embedding_state === 'failed'))
 const embeddingKeyHint = computed(() => form.embedding.hasApiKey ? '已保存，留空保持不变' : '可空')
 const rerankerKeyHint = computed(() => form.reranker.hasApiKey ? '已保存，留空保持不变' : '可空')
+// 每天最坏情况下的模型调用次数：min(每日总量, 1440/最小间隔 × 单轮上限)
+const consolidationDailyWorstCase = computed(() => {
+  const perRun = Math.max(0, Number(form.consolidation.llmCallsPerRun) || 0)
+  const daily = Math.max(0, Number(form.consolidation.dailyLlmCalls) || 0)
+  const interval = Math.max(1, Number(form.consolidation.minIntervalMinutes) || 1)
+  return Math.min(daily, Math.ceil(1440 / interval) * perRun)
+})
 
 function sumRows(predicate) { return stats.rows.filter(predicate).reduce((sum, row) => sum + row.count, 0) }
 function providerPayload(provider, headersText) {
@@ -484,7 +497,13 @@ function payload() {
   return {
     enabled: form.enabled, topK: form.topK, textCandidates: form.textCandidates, vectorCandidates: form.vectorCandidates, recordUnengagedEvents: form.recordUnengagedEvents,
     activeSearch: { enabled: form.activeSearch.enabled, timeoutMs: form.activeSearch.timeoutMs },
-    consolidation: { enabled: form.consolidation.enabled, idleDelayMinutes: form.consolidation.idleDelayMinutes, llmCallsPerRun: form.consolidation.llmCallsPerRun },
+    consolidation: {
+      enabled: form.consolidation.enabled,
+      idleDelayMinutes: form.consolidation.idleDelayMinutes,
+      minIntervalMinutes: form.consolidation.minIntervalMinutes,
+      llmCallsPerRun: form.consolidation.llmCallsPerRun,
+      dailyLlmCalls: form.consolidation.dailyLlmCalls,
+    },
     contextBudget: { enabled: form.contextBudget.enabled, dynamicTokens: form.contextBudget.dynamicTokens },
     embedding: providerPayload(form.embedding, embeddingHeaders.value),
     reranker: providerPayload(form.reranker, rerankerHeaders.value),
@@ -608,10 +627,29 @@ async function triggerConsolidation() {
   try {
     const result = await runConsolidationNow()
     if (result.skipped) {
-      notify(result.skipped === 'chat-active' ? '正在聊天中，稍后再整理' : '本轮未满足整理条件')
+      const reason = {
+        'chat-active': '正在聊天中，稍后再整理',
+        'not-idle': '距离上次聊天还太近，等用户安静下来再整理',
+        'min-interval': '距离上次整理还不到最小间隔',
+        'scan-backoff': '上次没有可整理的内容，正在退避中',
+        'already-running': '已有一轮整理在进行中',
+        disabled: '记忆整理已关闭或记忆系统未启用',
+      }[result.skipped] || '本轮未满足整理条件'
+      notify(reason)
     } else {
       const calls = result.llmCallsUsed ?? 0
-      notify(`整理完成，本轮调用 ${calls} 次记忆整理模型`)
+      const jobs = result.jobsExecuted ?? 0
+      // 手动触发会绕开空闲/间隔闸门，但仍受每日总量约束——额度用尽时要说清楚原因，
+      // 否则用户会以为"没有需要整理的记忆"
+      const budgetExhausted = result.dailyLlmCalls != null
+        && (result.dailyLlmCallsUsed ?? 0) >= result.dailyLlmCalls
+      if (jobs === 0) {
+        notify(budgetExhausted ? '今日模型调用额度已用完，本轮未做整理' : '本轮没有需要整理的记忆')
+      } else if (budgetExhausted) {
+        notify(`整理完成（今日模型额度已用完），执行 ${jobs} 个任务、调用 ${calls} 次模型`)
+      } else {
+        notify(`整理完成，执行 ${jobs} 个任务、调用 ${calls} 次记忆整理模型`)
+      }
     }
     await loadIndexJobs()
   } catch (error) { notify(`整理失败：${error.message}`, 'error') }


### PR DESCRIPTION
﻿记忆整理 daemon 修复：候选消费记账消除无限重复送 LLM + 预算语义归位 + 任务轮转防饥饿

问题（真实内存库实测确认，非推测）

1. 候选发现只按时间窗与状态筛选，而模型判定“无关 / 归纳不出结论 / 补不出字段”时不产生
   任何内容写入，候选永远不会消失；叠加“空闲判定在用户离开后恒为真”，等于每 5 分钟把同一
   批候选重问一遍（实测 T1 连续 5 轮扫描：花 5 次 LLM、0 次落地）。
2. 旧键 dailyMaxLlmCalls 语义本是“每日总量”，改名时被接到“每轮预算”，预算被放大 288 倍
   （每 5 分钟一轮 × 6 次），最坏 6 × 288 次/天。
3. claimNextJob 只按优先级排序，T4/T5 会被 T1/T2 吃满预算长期饿死。

修复

- 新增 memory_consolidation_marks 记账表 + 分任务 TTL（conflict 7 / generalize 30 /
  portrait_suggest 14 / backfill 30 天）：四个 runner 在 LLM 成功返回后无条件记账（调用抛错
  则不记账、下轮重试），四个候选发现函数按记账过滤。
- dailyMaxLlmCalls → dailyLlmCalls（每日总量，持久化 state.daily、按上海日期归零）；
  llmCallsPerRun 默认 6 → 3；新增 minIntervalMinutes（默认 60）；空转轮退避 30 分钟；
  22 小时兜底改锚 lastWorkedAt（原先空转轮也刷 lastFinishedAt，兜底线永不触发）。
- claimNextJob 同优先级改为按“该类型上次完成时间”轮转领取。
- T5 逐字段比对，只在字段真的变化时写库并置 stale（原先模型留空也刷 updated_at，并用完全
  相同的文本重复付费重嵌入）；整批记账后不再回环。
- T3 强度未变化不写库（strength IS NOT ?）、语句移出循环；新增 pruneConsolidationArtifacts
  按保留期清理审计 90 天 / 已终结任务 7 天 / 过期记账 180 天。
- 新增 migrateMemoryConsolidationSettings：老库启动时幂等补全 consolidation 配置块并把旧键
  归位（只补缺失键、不覆盖用户值）。
- 群聊 SSE 与冷场续聊登记 chatActivity（原先只有 1v1 聊天让 daemon 让路）。
- 审计 query 1000 → 200 字（curation 的“查询”其实是整段 40 条对话）并为 created_at 补索引。

与上游 0aec549「暂时关闭T4 记忆」的关系

上游关 T4 的根因是“同一批记忆恒为候选、每轮重复送 LLM、产出换词重述的近似建议”。本 PR 用
候选消费记账 + 分任务 TTL 从根上消除重复（问过且无结论的候选按 TTL 退出候选集），因此
portraitSuggest 默认值取 true（T4 默认开启）；上游那 24 小时按天冷却作为次级限流保留，开关
同样保留，若希望维持默认关闭，把 consolidate 配置里的 portraitSuggest 置为 false 即可。
同时保留上游的待确认建议积压上限（PORTRAIT_PENDING_LIMIT）作为第二道闸门。

顺带修正：migrateMemoryConsolidationSettings 的字段白名单漏了 portraitSuggest，会把用户
显式关掉的 T4 在迁移时悄悄改回开启；现已纳入白名单并补回归测试。

测试

新增 20 例（T1 连续 5 轮只花 1 次 LLM、TTL 到期可重整理、LLM 失败不记账、T2/T4 不重问、
T5 留空不写库不回环、四道闸门决策与跨日额度归零、迁移幂等与旧键归位、用户关掉的 T4 不被
迁移改回、保留期清理不碰 pending、强度未变不写库），全量 98/98 通过。

