### PR TITLE
修复两处未定义符号漏洞：免费鸡蛋换模型守卫失效 + 无效 workflow 报错文案崩溃

### DIFF
--- a/agent-core/src/llm/llm-client.js
+++ b/agent-core/src/llm/llm-client.js
@@ -348,8 +348,11 @@ async function* _chatStreamFreeEgg(messages, opts) {
       lastError.__freeEggFailover = true;
       throw lastError;
     }
+    // attemptYielded 必须声明在 try 之外：catch 块要读它。
+    // 原先写在 try 内，let 的块作用域使 catch 里的读取必然抛 ReferenceError，
+    // 于是"已输出内容就不再换模型"的守卫从未生效，真实错误也被替换成 "attemptYielded is not defined"。
+    let attemptYielded = false;
     try {
-      let attemptYielded = false;
       for await (const delta of _chatStreamInner(messages, { ...opts, model })) {
         attemptYielded = true;
         yield delta;

--- a/agent-core/src/services/imageSkill.js
+++ b/agent-core/src/services/imageSkill.js
@@ -129,7 +129,7 @@ function buildWorkflow(promptText, overrides = {}) {
   const workflow = JSON.parse(fs.readFileSync(wfPath, 'utf8'));
   let wf = apiToGui(workflow);
   if (!Array.isArray(wf.nodes)) {
-    throw new Error(`Workflow "${wfName}" is invalid: missing "nodes" array and could not be parsed as an API-format workflow. Please use ComfyUI's regular "Save" (not "Export (API)") to export the workflow.`);
+    throw new Error(`Workflow "${path.basename(wfPath)}" is invalid: missing "nodes" array and could not be parsed as an API-format workflow. Please use ComfyUI's regular "Save" (not "Export (API)") to export the workflow.`);
   }
   wf = JSON.parse(JSON.stringify(wf));
 


### PR DESCRIPTION
﻿修复两处"未定义符号"漏洞（免费鸡蛋换模型守卫失效 + 无效 workflow 报错文案崩溃）

均为历史遗留缺陷，main 与上游同时存在，与任何一次合版无关；用 no-undef 全量扫描
（agent-core/src + app.js）发现。

1. agent-core/src/llm/llm-client.js —— 免费鸡蛋流式：换模型守卫从未生效

   `let attemptYielded` 原本声明在 try 块内，却在 catch 块里读取。let 是块作用域，
   该读取必然抛 ReferenceError：
     - "已输出过内容就不再换模型"的守卫从未生效——用户已经看到前半句话，失败后仍会
       切到下一个免费模型重来一遍；
     - 真实的上游错误被替换成 "attemptYielded is not defined"，排障时看不到根因。
   修法：把声明提到 try 之外（仍在 for 循环体内，保持每次尝试独立计数）。

2. agent-core/src/services/imageSkill.js —— 无效 workflow 的报错文案崩掉

   报错模板里插值 `wfName`，全仓无此符号，而 `path` 已在该文件导入。
   触发条件为 workflow JSON 缺 nodes 数组（典型场景：用户用 ComfyUI 的
   "Export (API)" 而不是 "Save" 导出的文件）。
   本该提示"请用 ComfyUI 的 Save 而非 Export(API)"，实际抛出 ReferenceError，
   把真正的原因掩盖掉。
   修法：改用作用域内已有的 path.basename(wfPath)，与同函数 "Workflow not found"
   那条报错的口径一致。

未包含：routes/config.js 的 triggerWeatherUpdate 问题——上游已用
`triggerUpdate as triggerWeatherUpdate` 的导入别名修复，本 PR 不重复处理。

验证：全量测试 80/80 通过；两文件 node --check 通过。

