### PR TITLE
启动器：新增问题反馈通道与增量补丁通道（都不需要后端服务）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ output/
 .mimosa/
 *.apk
 HyperFrames/
+
+# 启动器问题反馈的本地产物（feedback/<问题ID>.txt）
+feedback/
+
+# 增量补丁的下载缓存与回滚备份（由 PatchManager 维护，不入库）
+.patch-cache/
+.patch-backup/

--- a/launcher/launcher/app.py
+++ b/launcher/launcher/app.py
@@ -13,8 +13,10 @@ from PySide6.QtWidgets import (
     QLabel,
     QHBoxLayout,
     QVBoxLayout,
+    QFileDialog,
     QGraphicsOpacityEffect,
     QGraphicsDropShadowEffect,
+    QMessageBox,
     QSizeGrip,
     QApplication,
 )
@@ -33,6 +35,8 @@ from .maibot_page import MaiBotPage, MAIBOT_ADMIN_URL, SNOWLUMA_ADMIN_URL
 from .version_page import VersionPage
 from .settings_page import SettingsPage
 from .qa_page import QAPage
+from .feedback_page import FeedbackPage
+from .patch_manager import PatchManager, PatchError, derive_patch_base
 
 
 # 窗口尺寸
@@ -192,6 +196,7 @@ class MainWindow(QMainWindow):
     PAGE_VERSION = 3
     PAGE_SETTINGS = 4
     PAGE_QA = 5
+    PAGE_FEEDBACK = 6
 
     def __init__(self):
         super().__init__()
@@ -205,6 +210,7 @@ class MainWindow(QMainWindow):
         self._build = BuildManager(self._project_path)
         self._runner = ServiceRunner(self._project_path)
         self._maibot_runner = MaiBotRunner(self._project_path)
+        self._patch = PatchManager(self._project_path, "")
 
         self._is_built = False
         self._switching_version = False
@@ -351,6 +357,15 @@ class MainWindow(QMainWindow):
         self._qa_page = QAPage()
         self._stack.addWidget(self._qa_page)
 
+        self._feedback_page = FeedbackPage(self._project_path)
+        self._feedback_page.set_context_provider(self._feedback_context)
+        self._feedback_page.set_issue_template(self._config.get("feedback_issue_template") or "")
+        self._feedback_page.set_channel(self._config.get("feedback_channel_url") or "")
+        self._feedback_page.report_saved.connect(
+            lambda path: self._log_page.append_log(f"[反馈] 报告已保存：{path}")
+        )
+        self._stack.addWidget(self._feedback_page)
+
         self._stack.setCurrentIndex(self.PAGE_HOME)
 
         # 标题栏按钮浮在页面之上
@@ -394,7 +409,7 @@ class MainWindow(QMainWindow):
         layout.addStretch()  # 把按钮推到底部
 
         self._nav_btns: list[QPushButton] = []
-        labels = ["首页", "日志", "MaiBot", "版本", "设置", "Q&A"]
+        labels = ["首页", "日志", "MaiBot", "版本", "设置", "Q&A", "反馈"]
 
         for i, label in enumerate(labels):
             btn = QPushButton(label, self._nav)
@@ -456,6 +471,22 @@ class MainWindow(QMainWindow):
         self._maibot_runner.status_changed.connect(self._on_maibot_status)
         self._maibot_runner.health_changed.connect(self._on_maibot_health)
 
+        # --- 增量补丁 ---
+        self._version_page.patch_check_clicked.connect(self._on_patch_check)
+        self._version_page.patch_apply_clicked.connect(self._on_patch_apply)
+        self._version_page.patch_rollback_clicked.connect(self._on_patch_rollback)
+        self._version_page.patch_source_saved.connect(self._on_patch_source_saved)
+        self._version_page.patch_import_clicked.connect(self._on_patch_import)
+
+        self._feedback_page.channel_saved.connect(self._on_feedback_channel_saved)
+
+        self._patch.manifest_ready.connect(self._on_patch_manifest)
+        self._patch.manifest_failed.connect(self._on_patch_failed)
+        self._patch.download_progress.connect(self._version_page.set_patch_progress)
+        self._patch.download_done.connect(self._on_patch_downloaded)
+        self._patch.failed.connect(self._on_patch_failed)
+        self._patch.status.connect(self._version_page.set_patch_status)
+
     # ==================================================================
     # 页面切换
     # ==================================================================
@@ -495,6 +526,11 @@ class MainWindow(QMainWindow):
             self._version_page.set_current_tag(self._cached_current_tag)
             self._version_page.set_tags(self._cached_tags)
             self._version_page.set_remote_status(self._cached_has_updates)
+            self._version_page.set_patch_source(self._patch_base())
+            self._refresh_patch_rollback()
+        elif index == self.PAGE_FEEDBACK:
+            # 进页面才重新采集：日志与环境信息要反映"现在"，不是启动时的快照
+            self._feedback_page.refresh_preview()
 
     def _on_slide_done(self):
         """动画结束，确保位置精确归位。"""
@@ -700,6 +736,169 @@ class MainWindow(QMainWindow):
                 self._version_page.append_log(f"[ERROR] checkout 失败: {message}")
                 self._version_page.set_building(False)
                 self._switching_version = False
+
+    # ==================================================================
+    # 增量补丁
+    # ==================================================================
+
+    def _on_patch_source_saved(self, url: str):
+        self._config.set("patch_base_url", url)
+        self._patch.set_base_url(self._patch_base())
+        self._version_page.set_patch_source(self._patch_base())
+        self._version_page.set_patch_status("补丁源已保存", ok=True)
+        self._version_page.append_log(
+            f"[补丁] 源地址：{self._patch_base() or '（为空，只能离线导入补丁包）'}"
+        )
+
+    def _patch_base(self) -> str:
+        """生效的补丁源：显式配置优先，否则按更新源推导（同仓库 patches 分支）。"""
+        configured = (self._config.get("patch_base_url") or "").strip()
+        return configured or derive_patch_base(self._config.get("repo_url") or "")
+
+    def _on_patch_check(self):
+        self._patch.set_project_path(self._project_path)
+        self._patch.set_base_url(self._patch_base())
+        self._version_page.set_patch_source(self._patch_base())
+        self._version_page.set_patch_busy(True)
+        self._patch.fetch_manifest()
+
+    def _on_patch_manifest(self, data: dict):
+        self._version_page.set_patch_busy(False)
+        patches = data.get("patches") or []
+        self._version_page.set_patches(patches, self._cached_current_tag or "")
+        self._version_page.set_patch_status(
+            f"共 {len(patches)} 个补丁，最新 {data.get('latest') or '?'}", ok=True
+        )
+        self._version_page.append_log(f"[补丁] 清单就绪：{len(patches)} 个")
+        self._refresh_patch_rollback()
+
+    def _on_patch_failed(self, message: str):
+        self._version_page.set_patch_busy(False)
+        if message != "已取消":
+            self._version_page.set_patch_status(message, ok=False)
+            self._version_page.append_log(f"[ERROR] [补丁] {message}")
+
+    def _refresh_patch_rollback(self):
+        """有备份才允许回滚；默认指向最近一次应用的补丁。"""
+        backups = self._patch.list_backups()
+        self._version_page.set_applied_patch(backups[0] if backups else "")
+
+    def _on_patch_apply(self, patch: dict):
+        current = (self._cached_current_tag or "").lstrip("v")
+        targets = [str(v).lstrip("v") for v in (patch.get("from") or [])]
+        if current and targets and current not in targets:
+            self._version_page.set_patch_status(
+                f"当前版本 {self._cached_current_tag} 不在该补丁适用范围内"
+                f"（适用 {'/'.join(targets)}）", ok=False,
+            )
+            return
+
+        if self._runner.is_any_running():
+            # Windows 下运行中的进程持有文件锁，覆盖文件前必须先停服务
+            self._version_page.append_log("正在停止服务（应用补丁需要独占文件访问）...")
+            self._runner.stop_all()
+            QTimer.singleShot(5000, lambda: self._patch.download_patch(patch))
+        else:
+            self._patch.download_patch(patch)
+
+    def _on_patch_downloaded(self, local_path: str, patch: dict):
+        self._apply_patch_file(local_path, patch)
+
+    def _on_patch_import(self):
+        """离线通道：直接挑一个补丁包应用，不需要任何托管。
+
+        适用于"你把 .tar.gz 发给用户"的场景（QQ/网盘/U 盘/共享目录都行），
+        也适用于补丁源是本地目录时手工取包。
+        """
+        path, _ = QFileDialog.getOpenFileName(
+            self, "选择补丁包", "", "增量补丁 (*.tar.gz);;所有文件 (*)"
+        )
+        if not path:
+            return
+        try:
+            meta = PatchManager.read_meta(path)
+        except PatchError as exc:
+            self._on_patch_failed(str(exc))
+            return
+
+        targets = "、".join(str(v) for v in (meta.get("from") or [])) or "任意版本"
+        reply = QMessageBox.question(
+            self, "应用本地补丁",
+            f"补丁：{meta.get('to')}\n适用版本：{targets}\n"
+            f"说明：{meta.get('notes') or '（无）'}\n\n"
+            "将覆盖项目里的变更文件（原文件先备份，可回滚），之后需要强制重新构建。",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply != QMessageBox.Yes:
+            return
+
+        if self._runner.is_any_running():
+            self._version_page.append_log("正在停止服务（应用补丁需要独占文件访问）...")
+            self._runner.stop_all()
+            QTimer.singleShot(5000, lambda: self._apply_patch_file(path, meta))
+            return
+
+        self._apply_patch_file(path, meta)
+
+    def _apply_patch_file(self, local_path: str, patch: dict):
+        """落盘 + 记录回滚点。下载通道与导入通道共用。"""
+        try:
+            summary = self._patch.apply_patch(
+                local_path,
+                expected_from=[str(v) for v in (patch.get("from") or [])],
+                current_version=self._cached_current_tag or "",
+            )
+        except PatchError as exc:
+            self._on_patch_failed(str(exc))
+            return
+        self._version_page.set_patch_busy(False)
+        self._version_page.set_patch_status(summary, ok=True)
+        self._version_page.append_log(f"[补丁] {summary}")
+        self._log_page.append_log(f"[补丁] {summary}")
+        self._version_page.set_applied_patch(patch.get("id") or "")
+
+    def _on_patch_rollback(self, patch_id: str):
+        try:
+            message = self._patch.rollback(patch_id)
+        except PatchError as exc:
+            self._on_patch_failed(str(exc))
+            return
+        self._version_page.set_patch_status(message, ok=True)
+        self._version_page.append_log(f"[补丁] {message}")
+        self._log_page.append_log(f"[补丁] {message}")
+        self._refresh_patch_rollback()
+
+    # ==================================================================
+    # 问题反馈
+    # ==================================================================
+
+    def _on_feedback_channel_saved(self, url: str):
+        """保存备用反馈渠道。GitHub 直连不通时，「提交反馈」会自动改开这个链接。"""
+        self._config.set("feedback_channel_url", url)
+        self._feedback_page.set_channel(url)
+        self._log_page.append_log(f"[反馈] 备用渠道已保存：{url or '（清空）'}")
+
+    def _feedback_context(self) -> dict:
+        """反馈页取报告时回调：给"此刻"的版本与服务状态，而不是启动时的快照。"""
+        services: dict[str, str] = {}
+        try:
+            services["向量服务(:8765)"] = (
+                "运行中" if self._log_page.vector_indicator._running else "已停止"
+            )
+            services["主控后端(:3099)"] = (
+                "运行中" if self._log_page.agent_indicator._running else "已停止"
+            )
+        except Exception:  # noqa: BLE001 - 采集失败不该影响反馈本身
+            pass
+        return {
+            "launcher_version": self._config.get("version_display") or "",
+            "current_tag": self._cached_current_tag or self._config.get("current_tag") or "",
+            # get_tags 按 creatordate 倒序，首条即已知最新
+            "remote_tag": (self._cached_tags[0].get("name") if self._cached_tags else ""),
+            "project_path": self._project_path,
+            "repo_url": self._config.get("repo_url") or "",
+            "services": services,
+        }
 
     # ==================================================================
     # Build 信号

--- a/launcher/launcher/config_manager.py
+++ b/launcher/launcher/config_manager.py
@@ -17,6 +17,18 @@ DEFAULT_CONFIG = {
     "version_display": "",  # 持久化版本信息，启动即可显示
     "use_mirror": True,  # 使用国内镜像源加速 npm/pip 依赖下载
     "extra_lora_folders": "",  # 额外 LoRA 文件夹路径，多个用;分隔；留空则仅从 ComfyUI/models/loras 读取
+    # --- 增量补丁 ---
+    # 补丁源：存放 index.json 与 *.tar.gz 的静态目录（对象存储 / 自建站 / 本地或共享目录都行）。
+    # 留空则按 repo_url 自动推导为「同仓库的 patches 分支」——本地程序无法被推送，只能主动去拉，
+    # 而代码仓库本来就得能访问，所以默认复用它，零新增托管。
+    "patch_base_url": "",
+    # --- 问题反馈 ---
+    # 提交地址模板，支持 {slug} {issue_id} {title} {body} 占位符；默认是 GitHub issue 预填链接
+    #（客户端因此不需要内置任何 token）。
+    "feedback_issue_template": "https://github.com/{slug}/issues/new?title={title}&body={body}",
+    # 备用反馈渠道：主渠道直连不通时自动改开这个链接（QQ 群 / 问卷 / B站视频页）。
+    # 无论走哪条路，报告都会先复制到剪贴板，用户粘贴即可。
+    "feedback_channel_url": "",
     # --- MaiBot ---
     "maibot_autostart": False,  # 点击一键启动邻舍时同时启动 MaiBot
     "maibot_browser_maibot": True,  # MaiBot 就绪后自动打开后台 (8001)

--- a/launcher/launcher/feedback_page.py
+++ b/launcher/launcher/feedback_page.py
@@ -1,0 +1,505 @@
+"""
+问题反馈页 —— 用户只写「问题描述」，日志与环境信息由系统自动采集，
+并给每条反馈打一个问题 ID。
+
+为什么不做「一键直接上报到服务器」：
+  客户端内置 GitHub token 等于把写入凭据公开分发给所有人；而自建接收服务
+  又不该在没有服务端之前先写进客户端。所以这里的口径是：
+    · 报告在本地生成（含问题 ID、脱敏后的日志），可保存成文件；
+    · 「打开反馈页」用 GitHub 的 issue 预填链接，用户点一下就直接带着正文到提交页；
+    · 正文过长时链接只带摘要，完整报告以附件文件为准。
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+
+from PySide6.QtCore import Qt, Signal, QTimer, QUrl
+from PySide6.QtGui import QDesktopServices, QFont
+from PySide6.QtNetwork import QNetworkAccessManager, QNetworkReply, QNetworkRequest
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPlainTextEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from . import logbus
+from .feedback_report import (
+    DEFAULT_LOG_LINES,
+    build_submit_url,
+    build_report_text,
+    collect_environment,
+    new_issue_id,
+    save_report,
+    template_carries_body,
+)
+
+_HINT = (
+    "日志与环境信息由系统自动采集，你只需要描述遇到的问题。"
+    "报告在本地生成，提交前会自动把 API Key、Token、用户名路径打码。"
+)
+
+
+class FeedbackPage(QWidget):
+    """问题反馈页面。"""
+
+    report_saved = Signal(str)          # 保存成功后的文件路径
+    issue_page_opened = Signal(str)     # 打开的反馈页 URL
+    channel_saved = Signal(str)         # 备用反馈渠道
+
+    # 探测超时：GitHub 在国内常见的是"连不上但也不立刻报错"，卡太久不如早点告诉用户
+    PROBE_TIMEOUT_MS = 3000
+
+    def __init__(self, project_path: str, parent=None):
+        super().__init__(parent)
+        self._project_path = project_path
+        self._context_provider = None
+        self._issue_id = new_issue_id()
+        self._report_text = ""
+        self._issue_template = ""
+        self._net = QNetworkAccessManager(self)
+        # 便于单测替换掉真实网络探测
+        self._probe_override = None
+        self._setup_ui()
+        self.refresh_preview()
+
+    # ------------------------------------------------------------------
+    # 对外
+    # ------------------------------------------------------------------
+
+    def set_project_path(self, path: str):
+        self._project_path = path
+
+    def set_context_provider(self, provider):
+        """provider() -> dict，字段见 collect_environment 的参数。
+
+        用回调而不是一次性传值，是为了让「当前版本 / 服务状态」在用户点开页面时
+        取到最新值，而不是启动时的快照。
+        """
+        self._context_provider = provider
+        self.refresh_preview()
+
+    # ------------------------------------------------------------------
+    # UI
+    # ------------------------------------------------------------------
+
+    def _setup_ui(self):
+        self.setStyleSheet("background: #F7F3F0;")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(20, 44, 20, 16)
+        layout.setSpacing(8)
+
+        header = QHBoxLayout()
+        title = QLabel("问题反馈")
+        title.setStyleSheet("color: #2E2A27; font-size: 18px; font-weight: bold;")
+        header.addWidget(title)
+        header.addStretch()
+
+        self._issue_label = QLabel()
+        self._issue_label.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        self._issue_label.setStyleSheet(
+            "color: #E07B6C; font-size: 13px; font-weight: bold;"
+            "background: #FCEDE9; border-radius: 6px; padding: 4px 10px;"
+        )
+        header.addWidget(self._issue_label)
+        layout.addLayout(header)
+
+        self._update_issue_label()
+
+        hint = QLabel(_HINT)
+        hint.setWordWrap(True)
+        hint.setStyleSheet("color: #756B65; font-size: 12px; line-height: 1.6;")
+        layout.addWidget(hint)
+
+        # --- 问题描述 ---
+        desc_label = QLabel("问题描述（必填）")
+        desc_label.setStyleSheet("color: #2E2A27; font-size: 13px; font-weight: 600;")
+        layout.addWidget(desc_label)
+
+        self.description_edit = QPlainTextEdit()
+        self.description_edit.setPlaceholderText(
+            "例如：群聊里角色回复半天不出来，刷新后一下子全冒出来；"
+            "私聊会提示「请求超时，请重试」。\n"
+            "尽量写清楚：在哪个页面、点了什么、期望什么、实际发生什么。"
+        )
+        self.description_edit.setFixedHeight(96)
+        self.description_edit.setStyleSheet(_editor_style())
+        self.description_edit.textChanged.connect(self._on_description_changed)
+        layout.addWidget(self.description_edit)
+
+        # --- 预览 ---
+        preview_row = QHBoxLayout()
+        preview_label = QLabel("将提交的内容（系统自动生成）")
+        preview_label.setStyleSheet("color: #2E2A27; font-size: 13px; font-weight: 600;")
+        preview_row.addWidget(preview_label)
+        preview_row.addStretch()
+
+        self.include_log_check = QCheckBox(f"附带最近 {DEFAULT_LOG_LINES} 行日志")
+        self.include_log_check.setChecked(True)
+        self.include_log_check.setStyleSheet("color: #756B65; font-size: 12px;")
+        self.include_log_check.stateChanged.connect(lambda _=0: self.refresh_preview())
+        preview_row.addWidget(self.include_log_check)
+
+        self.refresh_btn = QPushButton("刷新预览")
+        self.refresh_btn.setStyleSheet(_small_btn_style())
+        self.refresh_btn.clicked.connect(self.refresh_preview)
+        preview_row.addWidget(self.refresh_btn)
+        layout.addLayout(preview_row)
+
+        self.preview_edit = QPlainTextEdit()
+        self.preview_edit.setReadOnly(True)
+        font = QFont("Consolas", 9)
+        font.setStyleHint(QFont.Monospace)
+        self.preview_edit.setFont(font)
+        self.preview_edit.setStyleSheet(_editor_style())
+        layout.addWidget(self.preview_edit, stretch=1)
+
+        # --- 状态 + 操作 ---
+        self._status_label = QLabel("")
+        self._status_label.setWordWrap(True)
+        self._status_label.setStyleSheet("color: #4A9B4A; font-size: 12px;")
+        layout.addWidget(self._status_label)
+
+        actions = QHBoxLayout()
+
+        self.copy_btn = QPushButton("复制到剪贴板")
+        self.copy_btn.setStyleSheet(_btn_style())
+        self.copy_btn.clicked.connect(self._on_copy)
+        actions.addWidget(self.copy_btn)
+
+        self.save_btn = QPushButton("保存为文件")
+        self.save_btn.setStyleSheet(_btn_style())
+        self.save_btn.clicked.connect(self._on_save)
+        actions.addWidget(self.save_btn)
+
+        self.folder_btn = QPushButton("打开反馈文件夹")
+        self.folder_btn.setStyleSheet(_btn_style())
+        self.folder_btn.clicked.connect(self._on_open_folder)
+        actions.addWidget(self.folder_btn)
+
+        actions.addStretch()
+
+        self.submit_btn = QPushButton("提交反馈")
+        self.submit_btn.setStyleSheet(_primary_btn_style())
+        self.submit_btn.clicked.connect(self._on_submit)
+        actions.addWidget(self.submit_btn)
+
+        layout.addLayout(actions)
+
+        # --- 备用反馈渠道 ---
+        # 默认的反馈页是 GitHub，国内常常直连不上；这里可以指到 QQ 群 / 问卷 / B站视频页，
+        # 提交时会先探测一次可达性，连不上就自动改开这个渠道，并把报告放进剪贴板。
+        channel_row = QHBoxLayout()
+        channel_label = QLabel("备用渠道")
+        channel_label.setStyleSheet("color: #756B65; font-size: 11px;")
+        channel_row.addWidget(channel_label)
+
+        self.channel_edit = QLineEdit()
+        self.channel_edit.setPlaceholderText(
+            "打不开 GitHub 时改用的链接（QQ 群 / 问卷 / B站视频页，可留空）"
+        )
+        self.channel_edit.setStyleSheet(_input_style())
+        channel_row.addWidget(self.channel_edit, stretch=1)
+
+        self.channel_save_btn = QPushButton("保存")
+        self.channel_save_btn.setStyleSheet(_small_btn_style())
+        self.channel_save_btn.clicked.connect(
+            lambda: self.channel_saved.emit(self.channel_edit.text().strip())
+        )
+        channel_row.addWidget(self.channel_save_btn)
+        layout.addLayout(channel_row)
+
+    # ------------------------------------------------------------------
+    # 报告生成
+    # ------------------------------------------------------------------
+
+    def _update_issue_label(self):
+        self._issue_label.setText(f"问题ID：{self._issue_id}")
+
+    def refresh_preview(self):
+        """重新采集环境与日志并刷新预览。"""
+        context = {}
+        if self._context_provider is not None:
+            try:
+                context = self._context_provider() or {}
+            except Exception:  # noqa: BLE001 - 采集失败不该让页面报错
+                context = {}
+
+        environment = collect_environment(
+            launcher_version=context.get("launcher_version", ""),
+            current_tag=context.get("current_tag", ""),
+            remote_tag=context.get("remote_tag", ""),
+            project_path=context.get("project_path", self._project_path),
+            repo_url=context.get("repo_url", ""),
+            services=context.get("services") or {},
+            extra=context.get("extra") or {},
+        )
+        log_lines = logbus.snapshot(DEFAULT_LOG_LINES) if self.include_log_check.isChecked() else []
+
+        self._report_text = build_report_text(
+            issue_id=self._issue_id,
+            description=self.description_edit.toPlainText(),
+            environment=environment,
+            log_lines=log_lines,
+        )
+        self.preview_edit.setPlainText(self._report_text)
+        if log_lines:
+            self._set_status(f"已采集最近的 {len(log_lines)} 行日志", ok=True)
+
+    def _on_description_changed(self):
+        # 描述改动后同步进报告，避免用户复制到的是旧正文
+        if self._report_text:
+            self.refresh_preview()
+
+    def _set_status(self, text: str, *, ok: bool = True):
+        self._status_label.setText(text)
+        self._status_label.setStyleSheet(
+            f"color: {'#4A9B4A' if ok else '#D9434A'}; font-size: 12px;"
+        )
+
+    # ------------------------------------------------------------------
+    # 操作
+    # ------------------------------------------------------------------
+
+    def _require_description(self) -> bool:
+        text = self.description_edit.toPlainText().strip()
+        if not text:
+            self._set_status("请先填写问题描述（日志无需你填写）", ok=False)
+            self.description_edit.setFocus()
+            return False
+        return True
+
+    def _on_copy(self):
+        if not self._require_description():
+            return
+        self.refresh_preview()
+        from PySide6.QtWidgets import QApplication
+
+        QApplication.clipboard().setText(self._report_text)
+        self._set_status("已复制完整报告（含问题ID），可直接粘贴到任意反馈渠道")
+
+    def _on_save(self):
+        if not self._require_description():
+            return
+        self.refresh_preview()
+        try:
+            path = save_report(self._project_path, self._issue_id, self._report_text)
+        except OSError as exc:
+            self._set_status(f"保存失败：{exc}", ok=False)
+            return
+        self._set_status(f"已保存：{path}")
+        self.report_saved.emit(path)
+
+    def _on_open_folder(self):
+        folder = os.path.join(self._project_path, "feedback")
+        try:
+            os.makedirs(folder, exist_ok=True)
+        except OSError as exc:
+            self._set_status(f"无法创建反馈文件夹：{exc}", ok=False)
+            return
+        QDesktopServices.openUrl(QUrl.fromLocalFile(folder))
+
+    # ------------------------------------------------------------------
+    # 提交：先备齐 → 再试网页 → 试不通走备用渠道
+    # ------------------------------------------------------------------
+
+    def set_issue_template(self, template: str):
+        self._issue_template = (template or "").strip()
+
+    def set_channel(self, url: str):
+        self.channel_edit.setText(url or "")
+
+    def channel(self) -> str:
+        return self.channel_edit.text().strip()
+
+    def set_probe_override(self, probe):
+        """测试用：替换真实网络探测（``callable(url) -> bool``）。"""
+        self._probe_override = probe
+
+    def _prepare_payload(self) -> str:
+        """先把报告落盘并复制到剪贴板。
+
+        顺序很关键：默认反馈页是 GitHub，国内常常直连不上。无论后面网页能否打开，
+        用户手里都必须已经有一份完整报告能直接粘贴，否则一点"提交"就卡死在死链接上。
+        """
+        from PySide6.QtWidgets import QApplication
+
+        QApplication.clipboard().setText(self._report_text)
+        try:
+            path = save_report(self._project_path, self._issue_id, self._report_text)
+            self.report_saved.emit(path)
+            return path
+        except OSError:
+            return ""
+
+    def _submit_url(self) -> str:
+        context = {}
+        if self._context_provider is not None:
+            try:
+                context = self._context_provider() or {}
+            except Exception:  # noqa: BLE001
+                context = {}
+        return build_submit_url(
+            self._issue_template,
+            repo_url=context.get("repo_url", ""),
+            issue_id=self._issue_id,
+            description=self.description_edit.toPlainText(),
+            report=self._report_text,
+        )
+
+    def _on_submit(self):
+        if not self._require_description():
+            return
+        self.refresh_preview()
+        saved_path = self._prepare_payload()
+
+        url = self._submit_url()
+        if not url:
+            self._set_status(
+                "没有可用的反馈地址；报告已复制到剪贴板，"
+                f"请粘贴到任意反馈渠道（问题ID {self._issue_id}）",
+                ok=False,
+            )
+            return
+
+        self._set_status("报告已复制到剪贴板，正在检查反馈页能否打开…")
+        self.submit_btn.setEnabled(False)
+        self._probe(url, lambda reachable: self._finish_submit(reachable, url, saved_path))
+
+    def _probe(self, url: str, callback):
+        """探测反馈站点是否可达。只对 host 发 HEAD，不拉整个页面。"""
+        if self._probe_override is not None:
+            callback(bool(self._probe_override(url)))
+            return
+
+        target = QUrl(url)
+        if not target.host():
+            callback(False)
+            return
+        request = QNetworkRequest(QUrl(f"{target.scheme()}://{target.host()}/"))
+        request.setAttribute(
+            QNetworkRequest.Attribute.RedirectPolicyAttribute,
+            QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy,
+        )
+        reply = self._net.head(request)
+        settled = {"done": False}
+
+        def finish(reachable: bool):
+            if settled["done"]:
+                return
+            settled["done"] = True
+            reply.deleteLater()
+            callback(reachable)
+
+        def on_timeout():
+            reply.abort()
+            finish(False)
+
+        reply.finished.connect(
+            lambda: finish(reply.error() == QNetworkReply.NetworkError.NoError)
+        )
+        QTimer.singleShot(self.PROBE_TIMEOUT_MS, on_timeout)
+
+    def _finish_submit(self, reachable: bool, url: str, saved_path: str):
+        self.submit_btn.setEnabled(True)
+        channel = self.channel()
+
+        if reachable:
+            QDesktopServices.openUrl(QUrl(url))
+            self.issue_page_opened.emit(url)
+            tail = f"，同时已存到 {saved_path}" if saved_path else ""
+            hint = "" if template_carries_body(self._issue_template) else \
+                "（该渠道不会自动带正文，打开后按 Ctrl+V 粘贴）"
+            self._set_status(
+                f"已打开反馈页，问题ID {self._issue_id} 已写进标题{hint}{tail}", ok=True
+            )
+            return
+
+        # 连不上：不打开死链接，改用备用渠道；报告早已在剪贴板里
+        note = f"报告已复制到剪贴板，粘贴提交即可（问题ID {self._issue_id}）"
+        if channel:
+            QDesktopServices.openUrl(QUrl(channel))
+            self._set_status(
+                f"反馈页连不上（可能需要科学上网），已改用备用渠道；{note}", ok=False
+            )
+        else:
+            self._set_status(
+                f"反馈页连不上（可能需要科学上网），且未配置备用渠道；{note}", ok=False
+            )
+
+    def new_report(self):
+        """开一条新反馈：换问题 ID 并清空描述。"""
+        self._issue_id = new_issue_id()
+        self._update_issue_label()
+        self.description_edit.clear()
+        self._set_status("")
+        self.refresh_preview()
+
+
+# ----------------------------------------------------------------------
+# 与启动器其它页面一致的样式
+# ----------------------------------------------------------------------
+
+
+def _editor_style() -> str:
+    return """
+        QPlainTextEdit {
+            background: #FCFAF8;
+            color: #2E2A27;
+            border: 1px solid #E5D9D2;
+            border-radius: 6px;
+            padding: 8px;
+            selection-background-color: #F7D7D1;
+            selection-color: #2E2A27;
+        }
+    """
+
+
+def _btn_style() -> str:
+    return """
+        QPushButton {
+            background: #E5D9D2; color: #756B65; font-size: 12px;
+            padding: 8px 16px; border-radius: 6px; border: none;
+        }
+        QPushButton:hover { background: #DDD0C8; color: #2E2A27; }
+        QPushButton:disabled { background: #F1ECE8; color: #C9C0BB; }
+    """
+
+
+def _small_btn_style() -> str:
+    return """
+        QPushButton {
+            background: #E5D9D2; color: #756B65; font-size: 11px;
+            padding: 4px 10px; border-radius: 5px; border: none;
+        }
+        QPushButton:hover { background: #DDD0C8; color: #2E2A27; }
+    """
+
+
+def _input_style() -> str:
+    return """
+        QLineEdit {
+            background: #FCFAF8; color: #2E2A27;
+            border: 1px solid #E5D9D2; border-radius: 5px;
+            padding: 4px 8px; font-size: 11px;
+        }
+        QLineEdit:focus { border-color: #E07B6C; }
+    """
+
+
+def _primary_btn_style() -> str:
+    return """
+        QPushButton {
+            background: #E07B6C; color: #FCFAF8; font-size: 12px;
+            padding: 8px 18px; border-radius: 6px; border: none;
+        }
+        QPushButton:hover { background: #D96D5D; }
+        QPushButton:pressed { background: #C95F4F; }
+        QPushButton:disabled { background: #E5D9D2; color: #C9C0BB; }
+    """

--- a/launcher/launcher/feedback_report.py
+++ b/launcher/launcher/feedback_report.py
@@ -1,0 +1,252 @@
+"""
+问题反馈 —— 报告生成（纯逻辑，不依赖 PySide6，便于单独测试）。
+
+设计要点：
+1. 日志由系统采集（logbus + 环境探测），用户只填"问题描述"，不要求粘贴日志；
+2. 每条反馈带一个问题 ID（``LS-YYYYMMDD-XXXXXX``），由本地生成，无需服务端；
+3. 提交前统一脱敏：API Key / Token / Authorization 头 / 用户名路径一律打码，
+   避免用户把自己花钱买的密钥贴到公开 issue 里。
+"""
+from __future__ import annotations
+
+import os
+import re
+import secrets
+from datetime import datetime, timezone, timedelta
+
+# GitHub issue 预填链接（默认模板）。带 {body} 的模板能把整份报告塞进 URL，
+# 但这依赖目标站点能直连——国内访问 GitHub 经常不通，所以调用方必须先落盘+复制，
+# 再尝试打开；打不开就走备用渠道，用户手里始终有完整报告可粘贴。
+DEFAULT_ISSUE_TEMPLATE = "https://github.com/{slug}/issues/new?title={title}&body={body}"
+# 每行最多带多少字节的日志？报告本身不截断，只截 URL。
+DEFAULT_LOG_LINES = 200
+# GitHub 预填链接对 URL 长度敏感，超过这个字符数就只带摘要，完整内容走附件文件
+MAX_ISSUE_URL_CHARS = 6000
+
+_CST = timezone(timedelta(hours=8))  # 与项目其它地方的"上海日期"口径一致
+
+
+# ----------------------------------------------------------------------
+# 问题 ID
+# ----------------------------------------------------------------------
+
+def new_issue_id(now: datetime | None = None) -> str:
+    """生成问题 ID，形如 ``LS-20260911-3F9A2C``。"""
+    moment = (now or datetime.now(_CST)).astimezone(_CST)
+    suffix = secrets.token_hex(3).upper()
+    return f"LS-{moment:%Y%m%d}-{suffix}"
+
+
+# ----------------------------------------------------------------------
+# 脱敏
+# ----------------------------------------------------------------------
+
+_MASK_RULES: list[tuple[re.Pattern[str], str]] = [
+    # Bearer / Authorization
+    (re.compile(r"(?i)\b(bearer)\s+[A-Za-z0-9._\-]{8,}"), r"\1 ***"),
+    # sk-xxxx（OpenAI / DeepSeek 风格）
+    (re.compile(r"\bsk-[A-Za-z0-9_\-]{6,}"), "sk-***"),
+    # key=value / "key": "value" 里的密钥
+    (re.compile(r"(?i)(api[_-]?key\"?\s*[:=]\s*\"?)([A-Za-z0-9._\-]{6,})"), r"\1***"),
+    (re.compile(r"(?i)(access[_-]?token\"?\s*[:=]\s*\"?)([A-Za-z0-9._\-]{6,})"), r"\1***"),
+    (re.compile(r"(?i)(secret\"?\s*[:=]\s*\"?)([A-Za-z0-9._\-]{6,})"), r"\1***"),
+    # Windows 用户目录里的真实用户名
+    (re.compile(r"(?i)([A-Z]:\\Users\\)[^\\\s\"']+"), r"\1<user>"),
+    # 兜底：任何 32 位以上的连续密钥/哈希串
+    (re.compile(r"\b[A-Za-z0-9_\-]{32,}\b"), "***"),
+]
+
+
+def mask_secrets(text: str) -> str:
+    """把报告里可能出现的凭据打码。宁可多打，不可漏打。"""
+    if not text:
+        return ""
+    masked = text
+    for pattern, replacement in _MASK_RULES:
+        masked = pattern.sub(replacement, masked)
+    return masked
+
+
+# ----------------------------------------------------------------------
+# 环境信息
+# ----------------------------------------------------------------------
+
+def _safe(getter, default: str = "未知") -> str:
+    """探测类调用一律包一层：任何异常都不该让"生成反馈"本身失败。"""
+    try:
+        value = getter()
+    except Exception:  # noqa: BLE001 - 环境探测失败不能中断反馈
+        return default
+    if value is None or value == "":
+        return default
+    return str(value)
+
+
+def collect_environment(
+    *,
+    launcher_version: str = "",
+    current_tag: str = "",
+    remote_tag: str = "",
+    project_path: str = "",
+    repo_url: str = "",
+    services: dict[str, str] | None = None,
+    extra: dict[str, str] | None = None,
+) -> list[tuple[str, str]]:
+    """采集"简要日志"里那一段环境信息。顺序即展示顺序。"""
+    import platform
+    import sys
+
+    rows: list[tuple[str, str]] = [
+        ("启动器版本", launcher_version),
+        ("当前版本(tag)", current_tag),
+        ("远程最新(tag)", remote_tag),
+        ("操作系统", _safe(lambda: f"{platform.system()} {platform.release()} ({platform.version()})")),
+        ("系统架构", _safe(lambda: platform.machine())),
+        ("Python", _safe(lambda: sys.version.split()[0])),
+        ("项目目录", project_path),
+        ("更新源", repo_url),
+    ]
+
+    # Node 版本：项目跑在 bundle 的 node 上，取不到的常见原因是还没构建过
+    def _node_version() -> str:
+        import subprocess
+
+        node_exe = os.path.join(project_path, "runtime", "nodejs", "node.exe")
+        if not os.path.isfile(node_exe):
+            return "未找到（未构建？）"
+        out = subprocess.run(
+            [node_exe, "-v"], capture_output=True, text=True, timeout=5
+        )
+        return (out.stdout or out.stderr).strip() or "未知"
+
+    rows.append(("Node", _safe(_node_version)))
+
+    for name, status in (services or {}).items():
+        rows.append((f"服务·{name}", status))
+
+    for name, value in (extra or {}).items():
+        rows.append((name, value))
+
+    return [(k, mask_secrets(v)) for k, v in rows]
+
+
+# ----------------------------------------------------------------------
+# 报告正文
+# ----------------------------------------------------------------------
+
+def build_report_text(
+    *,
+    issue_id: str,
+    description: str,
+    environment: list[tuple[str, str]],
+    log_lines: list[str],
+    generated_at: datetime | None = None,
+) -> str:
+    """拼出完整的反馈正文（Markdown，便于直接贴进 issue）。"""
+    moment = (generated_at or datetime.now(_CST)).astimezone(_CST)
+    parts: list[str] = [
+        "# 邻舍.EXE 问题反馈",
+        "",
+        f"- 问题ID：**{issue_id}**",
+        f"- 生成时间：{moment:%Y-%m-%d %H:%M:%S} (UTC+8)",
+        "",
+        "## 问题描述",
+        "",
+        (description or "").strip() or "（未填写）",
+        "",
+        "## 环境信息",
+        "",
+    ]
+    for key, value in environment:
+        parts.append(f"- {key}：{value}")
+
+    parts.extend(["", f"## 最近日志（尾部 {len(log_lines)} 行，系统自动采集）", "", "```log"])
+    parts.extend(mask_secrets(line) for line in log_lines)
+    parts.extend(["```", ""])
+    return "\n".join(parts)
+
+
+def build_issue_title(issue_id: str, description: str) -> str:
+    """issue 标题：``[问题ID] 描述首行``，方便按 ID 检索。"""
+    first_line = ""
+    for line in (description or "").splitlines():
+        if line.strip():
+            first_line = line.strip()
+            break
+    if len(first_line) > 60:
+        first_line = first_line[:60] + "…"
+    return f"[{issue_id}] {first_line}" if first_line else f"[{issue_id}] 问题反馈"
+
+
+def build_submit_url(
+    template: str,
+    *,
+    repo_url: str,
+    issue_id: str,
+    description: str,
+    report: str,
+) -> str:
+    """按模板拼提交地址。
+
+    占位符：``{slug}``（owner/repo）、``{issue_id}``、``{title}``、``{body}``。
+    · 模板为空 → 回退到 GitHub issue 预填链接；
+    · 模板里没有 ``{body}``（问卷 / QQ 群 / B 站视频页这类）→ 正文只能靠剪贴板，
+      调用方必须把这一点告诉用户，不能默默让他提交一份空报告。
+    """
+    template = (template or "").strip() or DEFAULT_ISSUE_TEMPLATE
+    if "{" not in template:
+        return template
+
+    from urllib.parse import quote
+
+    body = report
+    if len(body) > MAX_ISSUE_URL_CHARS:
+        body = body[:MAX_ISSUE_URL_CHARS] + "\n\n…（正文过长已截断，完整报告见附件文件）"
+
+    return (
+        template
+        .replace("{slug}", quote(_github_slug(repo_url), safe="/"))
+        .replace("{issue_id}", quote(issue_id, safe=""))
+        .replace("{title}", quote(build_issue_title(issue_id, description), safe=""))
+        .replace("{body}", quote(body, safe=""))
+    )
+
+
+def template_carries_body(template: str) -> bool:
+    """模板能否把报告正文一起带过去（决定"打不开时是否必须手动粘贴"）。"""
+    return "{body}" in (template or DEFAULT_ISSUE_TEMPLATE)
+
+
+def build_issue_url(repo_url: str, *, issue_id: str, description: str, report: str) -> str:
+    """GitHub「新建 issue」预填链接（默认模板的便捷入口）。"""
+    return build_submit_url(
+        DEFAULT_ISSUE_TEMPLATE,
+        repo_url=repo_url,
+        issue_id=issue_id,
+        description=description,
+        report=report,
+    )
+
+
+def _github_slug(repo_url: str) -> str:
+    """从 ``https://github.com/owner/repo.git`` 提取 ``owner/repo``。"""
+    if not repo_url:
+        return ""
+    match = re.search(r"github\.com[:/]+([^/]+)/([^/\s]+?)(?:\.git)?/?$", repo_url.strip())
+    if not match:
+        return ""
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+# ----------------------------------------------------------------------
+# 落盘
+# ----------------------------------------------------------------------
+
+def save_report(project_path: str, issue_id: str, text: str) -> str:
+    """把报告写到 ``<项目>/feedback/<问题ID>.txt``，返回绝对路径。"""
+    folder = os.path.join(project_path, "feedback")
+    os.makedirs(folder, exist_ok=True)
+    path = os.path.join(folder, f"{issue_id}.txt")
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return path

--- a/launcher/launcher/log_widget.py
+++ b/launcher/launcher/log_widget.py
@@ -5,6 +5,8 @@ from PySide6.QtWidgets import QPlainTextEdit, QMenu
 from PySide6.QtGui import QTextCursor, QColor, QFont, QAction
 from PySide6.QtCore import Qt, Signal
 
+from . import logbus
+
 
 class LogWidget(QPlainTextEdit):
     """只读日志区域。自动着色、自动滚动、行数上限。"""
@@ -52,7 +54,7 @@ class LogWidget(QPlainTextEdit):
                 border: 1px solid #E5D9D2;
                 border-radius: 6px;
                 padding: 8px;
-                selection-background: #F7D7D1;
+                selection-background-color: #F7D7D1;
                 selection-color: #2E2A27;
             }
         """)
@@ -68,6 +70,10 @@ class LogWidget(QPlainTextEdit):
         智能滚动：仅当插入前用户在底部时才滚到新的底部，
         如果在上面看历史消息则不打扰。
         """
+        # 任何日志区的内容都汇入全局缓冲，反馈页据此自动生成"简要日志"，
+        # 用户不需要自己去别的标签页复制。集中在这一处，新增日志区自动覆盖。
+        logbus.append(text)
+
         color_name = color or self._detect_color(text)
         qcolor = self.COLORS.get(color_name, self.COLORS["white"])
 

--- a/launcher/launcher/logbus.py
+++ b/launcher/launcher/logbus.py
@@ -1,0 +1,43 @@
+"""
+全局日志环形缓冲 —— 所有 LogWidget 的输出都汇聚到这里。
+
+存在的理由：反馈页需要「系统自动生成的简要日志」，用户不应该自己去别的标签页
+复制粘贴。启动器里有多个互不相干的日志区（运行日志页、版本页、MaiBot 页），
+让每个调用点都手动再喂一份容易漏；改为在 LogWidget.append_line 这一个入口
+统一汇入，任何新增日志区都自动被覆盖。
+
+纯内存、进程内、有上限，不落盘（日志里可能有用户对话内容，不主动持久化）。
+"""
+from collections import deque
+from threading import Lock
+
+# 反馈只需要「最近发生了什么」，800 行足够覆盖一次故障的现场，也避免报告过大。
+MAX_LINES = 800
+
+_lock = Lock()
+_buffer: deque[str] = deque(maxlen=MAX_LINES)
+
+
+def append(text: str) -> None:
+    """记录一行日志（多行文本会按行拆开）。空行忽略。"""
+    if not text:
+        return
+    with _lock:
+        for raw in str(text).splitlines():
+            line = raw.rstrip()
+            if line:
+                _buffer.append(line)
+
+
+def snapshot(limit: int | None = None) -> list[str]:
+    """取最近若干行（时间正序）。limit 为 None 时取全部缓冲。"""
+    with _lock:
+        items = list(_buffer)
+    if limit is not None and limit > 0:
+        return items[-limit:]
+    return items
+
+
+def clear() -> None:
+    with _lock:
+        _buffer.clear()

--- a/launcher/launcher/patch_manager.py
+++ b/launcher/launcher/patch_manager.py
@@ -1,0 +1,544 @@
+"""
+增量补丁 —— 在线清单 / 下载 / 校验 / 应用 / 回滚。
+
+为什么不用「每次重新 git pull 整包」：
+  1. 现场网络差，整包反复下载失败率高，用户反复重试；
+  2. 每次都要走 GitHub，速度不受控；清单与补丁可以放到任意静态源
+     （对象存储 / 自建站 / 内网镜像），只要改 ``patch_base_url`` 即可。
+
+补丁是 tar.gz（Python 与 Node 双方标准库都能读写，不引入任何第三方依赖），
+结构固定：
+
+    patch.json          # 元信息：id / from / to / files[{path,sha256,size}] / deleted[]
+    files/<相对路径>    # 变更后文件的完整内容
+
+安全约束：解包时拒绝绝对路径、``..`` 穿越、符号链接与硬链接；并且一定会先解到
+临时目录、逐个校验 sha256 之后再落到项目里，失败自动回滚。
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tarfile
+import tempfile
+from urllib.parse import urljoin
+
+from PySide6.QtCore import QObject, QUrl, Signal
+from PySide6.QtNetwork import (
+    QNetworkAccessManager,
+    QNetworkProxy,
+    QNetworkReply,
+    QNetworkRequest,
+)
+
+# 补丁包与备份都放在项目根下的隐藏目录：不污染 git status（已在 .gitignore 中）
+CACHE_DIR_NAME = ".patch-cache"
+BACKUP_DIR_NAME = ".patch-backup"
+MANIFEST_NAME = "index.json"
+
+_SCHEMA = 1
+
+
+class PatchError(Exception):
+    """补丁相关的可预期失败（网络、校验、格式、应用），消息可直接给用户看。"""
+
+
+def sanitize_id(patch_id: str) -> str:
+    """补丁 ID 会被用作目录名，剔除一切路径相关字符。"""
+    keep = [ch for ch in str(patch_id) if ch.isalnum() or ch in "._-"]
+    return "".join(keep) or "patch"
+
+
+# 静态 raw 地址模板：把「代码仓库」直接当「补丁源」，不必再找托管。
+# 约定补丁放在同名仓库的 patches 分支根目录（二进制文件不污染主分支历史）。
+_RAW_TEMPLATES = {
+    "github.com": "https://raw.githubusercontent.com/{owner}/{repo}/patches/",
+    "gitee.com": "https://gitee.com/{owner}/{repo}/raw/patches/",
+}
+
+
+def derive_patch_base(repo_url: str) -> str:
+    """由更新源推导默认补丁源；认不出的托管返回空（让用户手填）。
+
+    本地程序无法被推送，只能主动去某个固定落点拉清单——而"代码仓库"本来就是
+    它必须能访问的那个落点。所以默认把 patches 分支当补丁源：零新增基础设施，
+    可达性与既有的版本更新完全一致。
+    """
+    match = re.search(r"([\w.-]+)[:/]+([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", repo_url or "")
+    if not match:
+        return ""
+    host, owner, repo = match.group(1).lower(), match.group(2), match.group(3)
+    for suffix, template in _RAW_TEMPLATES.items():
+        if host.endswith(suffix):
+            return template.format(owner=owner, repo=repo)
+    return ""
+
+
+def sha256_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _is_unsafe_member(name: str) -> bool:
+    """判断 tar 成员名是否有路径穿越风险。"""
+    if not name or name.startswith(("/", "\\")):
+        return True
+    if len(name) > 1 and name[1] == ":":  # C:\...
+        return True
+    parts = name.replace("\\", "/").split("/")
+    return any(part == ".." for part in parts)
+
+
+class PatchManager(QObject):
+    """补丁清单拉取、下载、校验、应用。所有网络动作走 Qt 事件循环，不阻塞 UI。"""
+
+    manifest_ready = Signal(dict)
+    manifest_failed = Signal(str)
+    download_progress = Signal(int, int)   # received, total
+    download_done = Signal(str, dict)      # local_path, patch_entry
+    apply_done = Signal(str)               # 人类可读的结果摘要
+    rollback_done = Signal(str)
+    failed = Signal(str)
+    status = Signal(str)
+
+    def __init__(self, project_path: str, base_url: str = "", parent=None):
+        super().__init__(parent)
+        self._project_path = project_path
+        self._base_url = self.normalize_base(base_url)
+        self._manager = QNetworkAccessManager(self)
+        self._reply: QNetworkReply | None = None
+        self._current: dict | None = None
+        self._dest_path = ""
+        # 直连失败后是否已经尝试过本地代理（只重试一次，避免反复探测）
+        self._proxy_tried = False
+
+    # ------------------------------------------------------------------
+    # 配置
+    # ------------------------------------------------------------------
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    @staticmethod
+    def normalize_base(raw: str) -> str:
+        """把用户填的补丁源规整成可用的基址。
+
+        补丁源本质上只是「一个能取到 index.json 的静态目录」，所以三种写法都收：
+          · HTTP(S) 目录   —— 对象存储 / 自建站 / Gitee raw / GitHub raw 都可以；
+          · 本地或共享目录 —— 本机文件夹、U 盘、``\\\\服务器\\共享`` 都行，
+                             自动转成 file:// （QNetworkAccessManager 原生支持 file 协议）；
+          · 留空           —— 关闭在线检查（仍可用「导入补丁包…」离线应用）。
+        """
+        text = (raw or "").strip()
+        if not text:
+            return ""
+        if text.startswith(("http://", "https://", "file://")):
+            return text.rstrip("/") + "/"
+        if re.match(r"^[A-Za-z]:[\\/]", text) or text.startswith("\\\\") or text.startswith("/"):
+            return QUrl.fromLocalFile(text.rstrip("\\/")).toString().rstrip("/") + "/"
+        return text.rstrip("/") + "/"
+
+    def set_base_url(self, base_url: str):
+        self._base_url = self.normalize_base(base_url)
+
+    def set_project_path(self, path: str):
+        self._project_path = path
+
+    def _retry_with_local_proxy(self) -> bool:
+        """直连失败时，复用 git 更新那套本地代理探测（只重试一次）。
+
+        这一点很关键：git_manager 在 fetch 时会自动探测本地代理端口（Clash 之类），
+        但 Qt 网络只认系统代理。如果不补这一步，就会出现"版本能更新、补丁下不动"
+        这种看起来毫无道理的现象 —— 明明同一个网络同一个仓库。
+        """
+        if self._proxy_tried:
+            return False
+        self._proxy_tried = True
+        try:
+            from .git_manager import _find_local_proxy
+            port = _find_local_proxy()
+        except Exception:  # noqa: BLE001 - 探测失败就当没代理
+            return False
+        if not port:
+            return False
+        self._manager.setProxy(
+            QNetworkProxy(QNetworkProxy.ProxyType.HttpProxy, "127.0.0.1", int(port))
+        )
+        self.status.emit(f"直连失败，已自动改用本地代理 127.0.0.1:{port}")
+        return True
+
+    def is_busy(self) -> bool:
+        return self._reply is not None
+
+    def cancel(self):
+        if self._reply is not None:
+            self._reply.abort()
+
+    # ------------------------------------------------------------------
+    # 清单
+    # ------------------------------------------------------------------
+
+    def manifest_url(self) -> str:
+        return urljoin(self._base_url, MANIFEST_NAME) if self._base_url else ""
+
+    def fetch_manifest(self):
+        """拉取 ``<base>/index.json``。"""
+        if self.is_busy():
+            return
+        if not self._base_url:
+            self.manifest_failed.emit("未配置补丁源地址（设置 → 补丁源）")
+            return
+
+        self.status.emit("正在获取补丁清单…")
+        self._reply = self._get(self.manifest_url())
+        self._reply.finished.connect(self._on_manifest_finished)
+
+    def _on_manifest_finished(self):
+        reply, self._reply = self._reply, None
+        if reply is None:
+            return
+        try:
+            if reply.error() != QNetworkReply.NetworkError.NoError:
+                if reply.error() == QNetworkReply.NetworkError.OperationCanceledError:
+                    self.manifest_failed.emit("已取消")
+                    return
+                if self._retry_with_local_proxy():
+                    self.fetch_manifest()
+                    return
+                self.manifest_failed.emit(self._network_error_text(reply))
+                return
+            raw = bytes(reply.readAll().data())
+        finally:
+            reply.deleteLater()
+
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            self.manifest_failed.emit(f"补丁清单格式不正确：{exc}")
+            return
+
+        patches = data.get("patches")
+        if not isinstance(patches, list):
+            self.manifest_failed.emit("补丁清单缺少 patches 数组")
+            return
+
+        self.status.emit(f"清单已就绪（{len(patches)} 个补丁）")
+        self.manifest_ready.emit(data)
+
+    # ------------------------------------------------------------------
+    # 下载
+    # ------------------------------------------------------------------
+
+    def download_patch(self, patch: dict):
+        """下载并校验单个补丁包。"""
+        if self.is_busy():
+            return
+        rel = str(patch.get("file") or patch.get("url") or "").strip()
+        if not rel:
+            self.failed.emit("补丁条目缺少 file 字段")
+            return
+
+        url = urljoin(self._base_url, rel)
+        patch_id = sanitize_id(patch.get("id") or os.path.basename(rel))
+        cache_dir = os.path.join(self._project_path, CACHE_DIR_NAME)
+        os.makedirs(cache_dir, exist_ok=True)
+        self._dest_path = os.path.join(cache_dir, f"{patch_id}.tar.gz.part")
+        self._current = patch
+
+        self.status.emit(f"正在下载补丁 {patch.get('id') or rel} …")
+        self._reply = self._get(url)
+        self._reply.downloadProgress.connect(self._on_download_progress)
+        self._reply.finished.connect(self._on_download_finished)
+
+    def _on_download_progress(self, received: int, total: int):
+        self.download_progress.emit(received, total)
+
+    def _on_download_finished(self):
+        reply, self._reply = self._reply, None
+        patch, self._current = self._current, None
+        if reply is None:
+            return
+        try:
+            if reply.error() != QNetworkReply.NetworkError.NoError:
+                self._cleanup_partial()
+                if reply.error() == QNetworkReply.NetworkError.OperationCanceledError:
+                    self.failed.emit("已取消")
+                    return
+                if patch and self._retry_with_local_proxy():
+                    self.download_patch(patch)
+                    return
+                self.failed.emit(self._network_error_text(reply))
+                return
+            data = bytes(reply.readAll().data())
+        finally:
+            reply.deleteLater()
+
+        expected = str((patch or {}).get("sha256") or "").strip().lower()
+        with open(self._dest_path, "wb") as handle:
+            handle.write(data)
+
+        actual = sha256_file(self._dest_path)
+        if expected and actual != expected:
+            self._cleanup_partial()
+            self.failed.emit(
+                f"补丁校验失败：期望 {expected[:12]}…，实际 {actual[:12]}…（下载可能被截断，请重试）"
+            )
+            return
+
+        final_path = self._dest_path[: -len(".part")]
+        os.replace(self._dest_path, final_path)
+        self.status.emit("下载完成，校验通过")
+        self.download_done.emit(final_path, patch or {})
+
+    def _cleanup_partial(self):
+        try:
+            if self._dest_path and os.path.exists(self._dest_path):
+                os.remove(self._dest_path)
+        except OSError:
+            pass
+
+    # ------------------------------------------------------------------
+    # 应用
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def read_meta(tar_path: str) -> dict:
+        """只读补丁包里的 patch.json。
+
+        给「导入本地补丁包…」用：先拿到 from/to 与说明，才能做版本校验与确认弹窗，
+        而不是先解包落到磁盘上再后悔。
+        """
+        try:
+            with tarfile.open(tar_path, "r:gz") as tar:
+                member = tar.getmember("patch.json")
+                handle = tar.extractfile(member)
+                if handle is None:
+                    raise PatchError("补丁包缺少 patch.json")
+                return json.loads(handle.read().decode("utf-8"))
+        except PatchError:
+            raise
+        except (tarfile.TarError, OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PatchError(f"不是有效的补丁包：{exc}") from exc
+
+    def apply_patch(self, tar_path: str, *, expected_from: list[str] | None = None,
+                    current_version: str = ""):
+        """把补丁落到项目目录。成功返回摘要字符串，失败抛 PatchError（已自动回滚）。"""
+        if not os.path.isfile(tar_path):
+            raise PatchError("补丁文件不存在，请重新下载")
+
+        with tempfile.TemporaryDirectory(prefix="linshe-patch-") as tmp:
+            meta = self._extract_to(tar_path, tmp)
+            self._validate_meta(meta, expected_from=expected_from, current_version=current_version)
+            return self._install(tmp, meta)
+
+    def _extract_to(self, tar_path: str, dest: str) -> dict:
+        """安全解包到独立目录，返回 patch.json 内容。"""
+        try:
+            with tarfile.open(tar_path, "r:gz") as tar:
+                for member in tar.getmembers():
+                    if _is_unsafe_member(member.name):
+                        raise PatchError(f"补丁包含不安全的路径：{member.name}")
+                    if member.issym() or member.islnk():
+                        raise PatchError(f"补丁包含链接文件（不允许）：{member.name}")
+                tar.extractall(dest)
+        except PatchError:
+            raise
+        except (tarfile.TarError, OSError) as exc:
+            raise PatchError(f"补丁解包失败：{exc}") from exc
+
+        meta_path = os.path.join(dest, "patch.json")
+        if not os.path.isfile(meta_path):
+            raise PatchError("补丁包缺少 patch.json")
+        try:
+            with open(meta_path, "r", encoding="utf-8") as handle:
+                meta = json.load(handle)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise PatchError(f"patch.json 解析失败：{exc}") from exc
+        if int(meta.get("schema", 0)) != _SCHEMA:
+            raise PatchError(f"补丁格式版本不支持：schema={meta.get('schema')}")
+        return meta
+
+    def _validate_meta(self, meta: dict, *, expected_from: list[str] | None,
+                       current_version: str):
+        files = meta.get("files")
+        if not isinstance(files, list) or not files:
+            raise PatchError("补丁不包含任何文件")
+
+        if expected_from and current_version:
+            normalized = {v.lstrip("v") for v in expected_from}
+            if current_version.lstrip("v") not in normalized:
+                raise PatchError(
+                    f"当前版本 {current_version} 不在该补丁的适用范围内"
+                    f"（适用：{'、'.join(expected_from)}），请改用手动切换版本"
+                )
+
+    def _install(self, staging: str, meta: dict) -> str:
+        patch_id = sanitize_id(meta.get("id") or "patch")
+        project = self._project_path
+        backup_root = os.path.join(project, BACKUP_DIR_NAME, patch_id)
+        files_root = os.path.join(staging, "files")
+
+        # 先全部校验，再动项目目录上的任何文件
+        staged: list[tuple[str, str]] = []
+        for item in meta["files"]:
+            rel = str(item.get("path") or "").replace("\\", "/")
+            if not rel or _is_unsafe_member(rel):
+                raise PatchError(f"补丁条目路径非法：{rel}")
+            source = os.path.join(files_root, *rel.split("/"))
+            if not os.path.isfile(source):
+                raise PatchError(f"补丁缺少文件内容：{rel}")
+            expected = str(item.get("sha256") or "").lower()
+            if expected and sha256_file(source) != expected:
+                raise PatchError(f"补丁内文件校验失败：{rel}")
+            staged.append((rel, source))
+
+        deleted = [str(p).replace("\\", "/") for p in (meta.get("deleted") or [])]
+        for rel in deleted:
+            if not rel or _is_unsafe_member(rel):
+                raise PatchError(f"补丁删除条目路径非法：{rel}")
+
+        journal: list[dict] = []
+        try:
+            os.makedirs(backup_root, exist_ok=True)
+            for rel, source in staged:
+                target = os.path.join(project, *rel.split("/"))
+                existed = os.path.exists(target)
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+                journal.append(self._backup(project, backup_root, rel,
+                                            action="update" if existed else "add"))
+                shutil.copy2(source, target)
+
+            for rel in deleted:
+                target = os.path.join(project, *rel.split("/"))
+                if not os.path.exists(target):
+                    continue
+                journal.append(self._backup(project, backup_root, rel, action="delete"))
+                os.remove(target)
+
+        except (OSError, PatchError) as exc:
+            self._restore(backup_root, journal)
+            raise PatchError(f"应用补丁失败，已回滚：{exc}") from exc
+
+        with open(os.path.join(backup_root, "applied.json"), "w", encoding="utf-8") as handle:
+            json.dump({"id": patch_id, "to": meta.get("to"), "journal": journal}, handle,
+                      ensure_ascii=False, indent=2)
+
+        added = sum(1 for entry in journal if entry.get("action") == "add")
+        removed = sum(1 for entry in journal if entry.get("action") == "delete")
+        summary = [f"更新 {len(staged) - added} 个文件"]
+        if added:
+            summary.append(f"新增 {added} 个")
+        if removed:
+            summary.append(f"删除 {removed} 个")
+        return (f"已应用补丁 {patch_id}：" + "，".join(summary)
+                + "。请到「版本」页强制重新构建后生效。")
+
+    def _backup(self, project: str, backup_root: str, rel: str, *, action: str) -> dict:
+        """把将被覆盖/删除的文件存进备份目录（``add`` 无需备份）。"""
+        entry = {"path": rel, "action": action}
+        if action == "add":
+            return entry
+        source = os.path.join(project, *rel.split("/"))
+        dest = os.path.join(backup_root, "files", *rel.split("/"))
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        shutil.copy2(source, dest)
+        return entry
+
+    def _restore(self, backup_root: str, journal: list[dict]):
+        """按日志把项目目录恢复到打补丁之前（add 的删掉，其余从备份还原）。"""
+        for entry in reversed(journal):
+            rel = str(entry.get("path") or "")
+            if not rel or _is_unsafe_member(rel):
+                continue
+            target = os.path.join(self._project_path, *rel.split("/"))
+            try:
+                if entry.get("action") == "add":
+                    if os.path.exists(target):
+                        os.remove(target)
+                else:
+                    backup = os.path.join(backup_root, "files", *rel.split("/"))
+                    if os.path.isfile(backup):
+                        os.makedirs(os.path.dirname(target), exist_ok=True)
+                        shutil.copy2(backup, target)
+            except OSError:
+                pass
+
+    # ------------------------------------------------------------------
+    # 回滚
+    # ------------------------------------------------------------------
+
+    def list_backups(self) -> list[str]:
+        root = os.path.join(self._project_path, BACKUP_DIR_NAME)
+        if not os.path.isdir(root):
+            return []
+        return sorted(
+            name for name in os.listdir(root)
+            if os.path.isfile(os.path.join(root, name, "applied.json"))
+        )
+
+    def rollback(self, patch_id: str) -> str:
+        """用备份目录还原某个补丁。"""
+        patch_id = sanitize_id(patch_id)
+        backup_root = os.path.join(self._project_path, BACKUP_DIR_NAME, patch_id)
+        journal_path = os.path.join(backup_root, "applied.json")
+        if not os.path.isfile(journal_path):
+            raise PatchError(f"找不到补丁 {patch_id} 的备份，无法回滚")
+        with open(journal_path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+
+        for entry in reversed(data.get("journal") or []):
+            rel = str(entry.get("path") or "")
+            if not rel or _is_unsafe_member(rel):
+                continue
+            target = os.path.join(self._project_path, *rel.split("/"))
+            # 与 _restore 同一套语义：add 的删掉，update/delete 的从备份还原。
+            # （曾经这里读的是另一个字段名，结果回滚变成了"把文件删掉"，务必保持一致）
+            action = entry.get("action") or ("update" if entry.get("existed") else "add")
+            try:
+                if action == "add":
+                    if os.path.exists(target):
+                        os.remove(target)
+                else:
+                    source = os.path.join(backup_root, "files", *rel.split("/"))
+                    if os.path.isfile(source):
+                        os.makedirs(os.path.dirname(target), exist_ok=True)
+                        shutil.copy2(source, target)
+            except OSError as exc:
+                raise PatchError(f"回滚 {rel} 失败：{exc}") from exc
+
+        shutil.rmtree(backup_root, ignore_errors=True)
+        return f"已回滚补丁 {patch_id}，请重新构建后生效。"
+
+    # ------------------------------------------------------------------
+    # 内部工具
+    # ------------------------------------------------------------------
+
+    def _get(self, url: str) -> QNetworkReply:
+        request = QNetworkRequest(QUrl(url))
+        request.setAttribute(
+            QNetworkRequest.Attribute.RedirectPolicyAttribute,
+            QNetworkRequest.RedirectPolicy.NoLessSafeRedirectPolicy,
+        )
+        request.setHeader(QNetworkRequest.KnownHeaders.UserAgentHeader, "LinsheLauncher-Patch/1.0")
+        # 补丁源常在对象存储上，缓存会拿到过期清单
+        request.setAttribute(
+            QNetworkRequest.Attribute.CacheLoadControlAttribute,
+            QNetworkRequest.CacheLoadControl.AlwaysNetwork,
+        )
+        return self._manager.get(request)
+
+    @staticmethod
+    def _network_error_text(reply: QNetworkReply) -> str:
+        code = reply.error()
+        if code == QNetworkReply.NetworkError.ContentNotFoundError:
+            return "补丁源返回 404：地址或文件不存在（检查设置里的补丁源）"
+        if code == QNetworkReply.NetworkError.OperationCanceledError:
+            return "已取消"
+        return f"网络请求失败：{reply.errorString()}"

--- a/launcher/launcher/version_page.py
+++ b/launcher/launcher/version_page.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout,
     QHBoxLayout,
     QLabel,
+    QLineEdit,
     QPushButton,
     QListWidget,
     QListWidgetItem,
@@ -14,6 +15,10 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, Signal, QPropertyAnimation, QEasingCurve
 from .log_widget import LogWidget
+
+# 补丁条目挂在 QListWidgetItem 上的附加数据：补丁本体 / 是否适用于当前版本
+_ROLE_PATCH = Qt.ItemDataRole.UserRole
+_ROLE_APPLICABLE = int(Qt.ItemDataRole.UserRole) + 1
 
 
 class SmoothListWidget(QListWidget):
@@ -67,17 +72,23 @@ class SmoothListWidget(QListWidget):
 
 class VersionPage(QWidget):
     """版本管理页面。"""
-
     # 信号
     check_update_clicked = Signal()
     switch_tag_clicked = Signal(str)  # tag
     force_rebuild_clicked = Signal()
     cancel_build_clicked = Signal()
+    # --- 增量补丁 ---
+    patch_source_saved = Signal(str)      # 补丁源地址
+    patch_check_clicked = Signal()
+    patch_apply_clicked = Signal(object)  # patch dict
+    patch_rollback_clicked = Signal(str)  # patch id
+    patch_import_clicked = Signal()       # 导入本地补丁包
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._current_tag: str | None = None
         self._building = False
+        self._applied_patch_id = ""
         self._setup_ui()
 
     def _setup_ui(self):
@@ -164,6 +175,83 @@ class VersionPage(QWidget):
         warn_label.setStyleSheet("color: #C88700; font-size: 12px;")
         layout.addWidget(warn_label)
 
+        # --- 增量补丁 ---
+        # 与「切换版本」互补：切版本要拉整包 + 全量构建，补丁只下发变更文件，
+        # 现场网络差时不用反复从 GitHub 下整包。
+        patch_header = QHBoxLayout()
+        patch_title = QLabel("增量补丁")
+        patch_title.setStyleSheet("color: #2E2A27; font-size: 12px; font-weight: 600;")
+        patch_header.addWidget(patch_title)
+
+        self.patch_status_label = QLabel("未检查")
+        self.patch_status_label.setStyleSheet("color: #756B65; font-size: 11px;")
+        patch_header.addWidget(self.patch_status_label)
+        patch_header.addStretch()
+        layout.addLayout(patch_header)
+
+        source_row = QHBoxLayout()
+        source_label = QLabel("补丁源")
+        source_label.setStyleSheet("color: #756B65; font-size: 11px;")
+        source_row.addWidget(source_label)
+
+        self.patch_source_edit = QLineEdit()
+        self.patch_source_edit.setPlaceholderText(
+            "静态目录：http(s) 网址，或本机/共享目录（如 D:\\patches、\\\\nas\\patches）"
+        )
+        self.patch_source_edit.setStyleSheet(_input_style())
+        source_row.addWidget(self.patch_source_edit, stretch=1)
+
+        self.patch_save_btn = QPushButton("保存源")
+        self.patch_save_btn.setStyleSheet(_small_btn_style())
+        self.patch_save_btn.clicked.connect(
+            lambda: self.patch_source_saved.emit(self.patch_source_edit.text().strip())
+        )
+        source_row.addWidget(self.patch_save_btn)
+        layout.addLayout(source_row)
+
+        self.patch_list = QListWidget()
+        self.patch_list.setMaximumHeight(76)
+        self.patch_list.setStyleSheet("""
+            QListWidget {
+                background: #FCFAF8; color: #2E2A27; border: 1px solid #E5D9D2;
+                border-radius: 6px; font-size: 12px;
+            }
+            QListWidget::item { border-bottom: 1px solid #F1ECE8; padding: 3px 6px; }
+            QListWidget::item:hover { background: #F1ECE8; }
+            QListWidget::item:selected { background: #F7D7D1; }
+        """)
+        self.patch_list.itemDoubleClicked.connect(lambda _item: self._on_patch_apply())
+        self.patch_list.currentItemChanged.connect(lambda *_: self._refresh_patch_buttons())
+        layout.addWidget(self.patch_list)
+
+        patch_btns = QHBoxLayout()
+
+        self.patch_check_btn = QPushButton("检查补丁")
+        self.patch_check_btn.setStyleSheet(_small_btn_style())
+        self.patch_check_btn.clicked.connect(self.patch_check_clicked.emit)
+        patch_btns.addWidget(self.patch_check_btn)
+
+        self.patch_apply_btn = QPushButton("应用选中补丁")
+        self.patch_apply_btn.setStyleSheet(_small_btn_style())
+        self.patch_apply_btn.setEnabled(False)
+        self.patch_apply_btn.clicked.connect(self._on_patch_apply)
+        patch_btns.addWidget(self.patch_apply_btn)
+
+        self.patch_rollback_btn = QPushButton("回滚已应用")
+        self.patch_rollback_btn.setStyleSheet(_small_btn_style())
+        self.patch_rollback_btn.setEnabled(False)
+        self.patch_rollback_btn.clicked.connect(self._on_patch_rollback)
+        patch_btns.addWidget(self.patch_rollback_btn)
+
+        # 离线通道：拿到一个 .tar.gz 就能应用，完全不依赖任何托管
+        self.patch_import_btn = QPushButton("导入补丁包…")
+        self.patch_import_btn.setStyleSheet(_small_btn_style())
+        self.patch_import_btn.clicked.connect(self.patch_import_clicked.emit)
+        patch_btns.addWidget(self.patch_import_btn)
+
+        patch_btns.addStretch()
+        layout.addLayout(patch_btns)
+
         # --- 操作日志 ---
         self.log_widget = LogWidget(self, max_lines=2000)
         self.log_widget.setMaximumHeight(120)
@@ -228,6 +316,101 @@ class VersionPage(QWidget):
 
     def append_log(self, text: str):
         self.log_widget.append_line(text)
+
+    # ------------------------------------------------------------------
+    # 增量补丁
+    # ------------------------------------------------------------------
+
+    def set_patch_source(self, url: str):
+        self.patch_source_edit.setText(url or "")
+
+    def patch_source(self) -> str:
+        return self.patch_source_edit.text().strip()
+
+    def set_patch_status(self, text: str, *, ok: bool | None = None):
+        self.patch_status_label.setText(text)
+        color = "#4A9B4A" if ok else ("#D9434A" if ok is False else "#756B65")
+        self.patch_status_label.setStyleSheet(f"color: {color}; font-size: 11px;")
+
+    def set_patches(self, patches: list, current_version: str = ""):
+        """填充补丁列表。``●`` = 适用于当前版本，``○`` = 需要先切到对应版本。"""
+        self.patch_list.clear()
+        current = (current_version or "").lstrip("v")
+        for patch in patches or []:
+            targets = [str(v) for v in (patch.get("from") or [])]
+            applicable = bool(current) and any(v.lstrip("v") == current for v in targets)
+            size_kb = (patch.get("size") or 0) / 1024
+            label = "可应用" if applicable else f"需先切到 {'/'.join(targets) or '?'}"
+            notes = f"　{patch['notes']}" if patch.get("notes") else ""
+            item = QListWidgetItem(
+                f"{'●' if applicable else '○'} {patch.get('to')}　{size_kb:.0f} KB　{label}{notes}"
+            )
+            item.setData(_ROLE_PATCH, patch)
+            item.setData(_ROLE_APPLICABLE, applicable)
+            self.patch_list.addItem(item)
+        if self.patch_list.count():
+            self.patch_list.setCurrentRow(0)
+        self._refresh_patch_buttons()
+
+    def set_patch_busy(self, busy: bool):
+        self.patch_check_btn.setEnabled(not busy)
+        self.patch_save_btn.setEnabled(not busy)
+        self.patch_import_btn.setEnabled(not busy)
+        self._refresh_patch_buttons()
+
+    def set_patch_progress(self, received: int, total: int):
+        if total > 0:
+            self.set_patch_status(
+                f"下载中 {received * 100 // total}%（{received // 1024}/{total // 1024} KB）"
+            )
+        else:
+            self.set_patch_status(f"下载中 {received // 1024} KB")
+
+    def set_applied_patch(self, patch_id: str | None):
+        """记录最近应用的补丁，决定「回滚」按钮是否可用。"""
+        self._applied_patch_id = patch_id or ""
+        self.patch_rollback_btn.setEnabled(bool(self._applied_patch_id))
+
+    def _selected_patch(self) -> dict | None:
+        item = self.patch_list.currentItem()
+        return item.data(_ROLE_PATCH) if item else None
+
+    def _refresh_patch_buttons(self):
+        """只有"选中 + 适用于当前版本 + 空闲"才允许点应用，避免误点导致失败。"""
+        item = self.patch_list.currentItem()
+        applicable = bool(item.data(_ROLE_APPLICABLE)) if item else False
+        self.patch_apply_btn.setEnabled(
+            item is not None and applicable and self.patch_check_btn.isEnabled()
+        )
+
+    def _on_patch_apply(self):
+        patch = self._selected_patch()
+        if not patch:
+            self.patch_apply_btn.setEnabled(False)
+            return
+        reply = QMessageBox.question(
+            self,
+            "应用补丁",
+            f"应用补丁 {patch.get('to')}？\n\n"
+            f"{patch.get('notes') or '（无说明）'}\n\n"
+            "变更文件会被覆盖，原文件先备份到 .patch-backup，随时可回滚；"
+            "应用后需要强制重新构建才会生效。",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            self.patch_apply_clicked.emit(patch)
+
+    def _on_patch_rollback(self):
+        if not self._applied_patch_id:
+            return
+        reply = QMessageBox.question(
+            self,
+            "回滚补丁",
+            f"回滚补丁 {self._applied_patch_id}？\n\n会还原被覆盖的文件，之后同样需要重新构建。",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            self.patch_rollback_clicked.emit(self._applied_patch_id)
 
     # ------------------------------------------------------------------
     # Slots
@@ -327,4 +510,26 @@ def _btn_style() -> str:
         }
         QPushButton:hover { background: #DDD0C8; color: #2E2A27; }
         QPushButton:disabled { background: #F1ECE8; color: #C9C0BB; }
+    """
+
+
+def _small_btn_style() -> str:
+    return """
+        QPushButton {
+            background: #E5D9D2; color: #756B65; font-size: 11px;
+            padding: 4px 10px; border-radius: 5px; border: none;
+        }
+        QPushButton:hover { background: #DDD0C8; color: #2E2A27; }
+        QPushButton:disabled { background: #F1ECE8; color: #C9C0BB; }
+    """
+
+
+def _input_style() -> str:
+    return """
+        QLineEdit {
+            background: #FCFAF8; color: #2E2A27;
+            border: 1px solid #E5D9D2; border-radius: 5px;
+            padding: 4px 8px; font-size: 11px;
+        }
+        QLineEdit:focus { border-color: #E07B6C; }
     """

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "install-apk": "node scripts/install-apk.mjs",
     "install-apk:n": "node scripts/install-apk.mjs -n",
     "build": "node scripts/build.mjs",
+    "build-patch": "node scripts/build-patch.mjs",
     "lasttag": "node scripts/lasttag.mjs",
     "restart-core": "node scripts/restart-core.mjs",
     "preview-launcher": "cd launcher && python main.py"

--- a/scripts/build-patch.mjs
+++ b/scripts/build-patch.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+/**
+ * 增量补丁生成器 —— 产出「两个版本之间」的最小补丁包，供启动器在线下载与落地。
+ *
+ *   node scripts/build-patch.mjs --from v3.4.0 --to v3.4.1 [--out patches]
+ *        [--from-versions v3.4.0,v3.4.1] [--notes "修复说明"] [--channel stable]
+ *
+ * 产物（默认写进 patches/，该目录可直接当静态源发布）：
+ *
+ *   <id>.tar.gz   补丁包：patch.json（元信息 + 每个文件的 sha256）+ files/<相对路径>
+ *   index.json    清单：latest / channel / patches[]（含大小与 sha256）
+ *
+ * 为什么是 tar.gz 而不是 zip：
+ *   Python 侧（启动器）用标准库 tarfile 读，Node 侧用 git archive 写，
+ *   两边都不需要任何第三方依赖，也不会踩 Windows 上 zip 的中文路径坑。
+ *
+ * 为什么用 git archive：
+ *   文件内容、可执行位、二进制、非 ASCII 路径全部由 git 自己处理，
+ *   比"逐个 git show 拼包"更可靠；脚本只负责把 patch.json 追加进 tar。
+ */
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import zlib from 'node:zlib';
+
+const SCHEMA = 1;
+
+// ── 参数 ──────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = { out: 'patches', channel: 'stable', notes: '', fromVersions: '', exclude: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+    if (!token.startsWith('--')) continue;
+    const key = token.slice(2);
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    if (key === 'exclude') {
+      args.exclude.push(value);   // 可重复
+      continue;
+    }
+    args[key] = value;
+  }
+  return args;
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (!args.from || !args.to) {
+  console.error(
+    '用法: node scripts/build-patch.mjs --from <ref> --to <ref> [--out patches] [--notes "…"]\n'
+    + '      [--source-only] [--exclude <glob>]... [--from-versions a,b] [--channel stable]'
+  );
+  process.exit(2);
+}
+
+const fromRef = args.from;
+const toRef = args.to;
+const outDir = path.resolve(args.out);
+const channel = String(args.channel || 'stable');
+
+// ── git 工具 ──────────────────────────────────────────────────────────
+
+function git(...argv) {
+  return execFileSync('git', argv, { encoding: 'utf8', maxBuffer: 512 * 1024 * 1024 }).trim();
+}
+
+function gitBuffer(...argv) {
+  return execFileSync('git', argv, { maxBuffer: 512 * 1024 * 1024 });
+}
+
+const fromSha = git('rev-parse', `${fromRef}^{commit}`);
+const toSha = git('rev-parse', `${toRef}^{commit}`);
+const fromDate = git('show', '-s', '--format=%cI', fromSha);
+const toDate = git('show', '-s', '--format=%cI', toSha);
+
+// ── 收集变更文件 ──────────────────────────────────────────────────────
+
+const rawDiff = git('diff', '--name-status', '-z', fromSha, toSha);
+const tokens = rawDiff.split('\0').filter(Boolean);
+
+const changed = [];   // { path, sha256, size }
+const deleted = [];
+
+for (let i = 0; i < tokens.length;) {
+  const status = tokens[i++];
+  if (status.startsWith('R') || status.startsWith('C')) {
+    const oldPath = tokens[i++];
+    const newPath = tokens[i++];
+    deleted.push(oldPath);
+    changed.push(newPath);
+  } else if (status === 'D') {
+    deleted.push(tokens[i++]);
+  } else {
+    // A / M / T 都按"内容变了"处理
+    changed.push(tokens[i++]);
+  }
+}
+
+// ── 排除构建产物 ──────────────────────────────────────────────────────
+// 默认把 agent-core/public 一起打进补丁的话，每发一版就多出几百 KB~MB 的
+// 内容哈希 bundle（文件名每次都变，历史里越堆越多）。而这些东西本地
+// 强制重新构建就会重新生成 —— 用户端「应用补丁 → 强制重新构建」本来就是既定流程。
+// 实测（5e3e0af→3b03b7b，含一次前端重建）：全量 866 KB → 只发源码 421 KB，
+// 排掉 51 个产物文件；产物占比越高的版本省得越多。
+
+function globToRegExp(glob) {
+  const escaped = glob.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  // 必须单次扫描替换：`**` 展开出来的 `.*` 若交给下一步的 `*` 规则再处理，
+  // 会被二次改写成 `.[^/]*`，于是 `a/**` 退化成"只匹配一层"（这个坑踩过一次）。
+  const pattern = escaped.replace(/\*\*\/|\*\*|\*/g, (match) => {
+    if (match === '**/') return '(?:.*/)?';
+    if (match === '**') return '.*';
+    return '[^/]*';
+  });
+  return new RegExp(`^${pattern}$`);
+}
+
+if (args['source-only'] !== undefined) args.exclude.push('agent-core/public/**');
+
+const excludeRules = args.exclude.map(globToRegExp).filter(Boolean);
+const isExcluded = (p) => excludeRules.some((re) => re.test(p));
+
+const droppedChanged = changed.filter(isExcluded);
+const droppedDeleted = deleted.filter(isExcluded);
+const keepChanged = changed.filter((p) => !isExcluded(p));
+const keepDeleted = deleted.filter((p) => !isExcluded(p));
+
+if (keepChanged.length === 0 && keepDeleted.length === 0) {
+  console.error(`[patch] ${fromRef} → ${toRef} 之间没有任何需要下发的文件差异，无需生成补丁`);
+  process.exit(1);
+}
+
+// ── tar 追加 ──────────────────────────────────────────────────────────
+// git archive 已经给出合法 tar；tar 允许直接追加条目，只需先去掉结尾的补零块。
+
+function tarHeader(name, size, mtimeSeconds) {
+  const block = Buffer.alloc(512);
+  const nameBuf = Buffer.from(name, 'utf8');
+
+  let prefix = '';
+  let shortName = name;
+  if (nameBuf.length > 100) {
+    // ustar 的长路径方案：prefix + "/" + name
+    const slash = nameBuf.lastIndexOf(0x2f); // '/'
+    if (slash < 0) throw new Error(`路径过长且无法拆分：${name}`);
+    prefix = nameBuf.subarray(0, slash).toString('utf8');
+    shortName = nameBuf.subarray(slash + 1).toString('utf8');
+    if (Buffer.byteLength(shortName) > 100 || Buffer.byteLength(prefix) > 155) {
+      throw new Error(`路径超过 ustar 上限：${name}`);
+    }
+  }
+
+  block.write(shortName, 0, 100, 'utf8');
+  block.write('0000644\0', 100, 8, 'ascii');   // mode
+  block.write('0000000\0', 108, 8, 'ascii');   // uid
+  block.write('0000000\0', 116, 8, 'ascii');   // gid
+  block.write(size.toString(8).padStart(11, '0') + '\0', 124, 12, 'ascii');
+  block.write(Math.floor(mtimeSeconds).toString(8).padStart(11, '0') + '\0', 136, 12, 'ascii');
+  block.write('        ', 148, 8, 'ascii');    // chksum 占位
+  block.write('0', 156, 1, 'ascii');           // typeflag: 普通文件
+  block.write('ustar\0', 257, 6, 'ascii');
+  block.write('00', 263, 2, 'ascii');
+  block.write('linshe\0', 265, 7, 'ascii');    // uname
+  block.write('linshe\0', 297, 7, 'ascii');    // gname
+  if (prefix) block.write(prefix, 345, 155, 'utf8');
+
+  let sum = 0;
+  for (const byte of block) sum += byte;
+  block.write(sum.toString(8).padStart(6, '0') + '\0 ', 148, 8, 'ascii');
+  return block;
+}
+
+function appendEntry(tarBuf, name, content, mtimeSeconds) {
+  const header = tarHeader(name, content.length, mtimeSeconds);
+  const padded = Buffer.alloc(Math.ceil(content.length / 512) * 512);
+  content.copy(padded);
+  // 去掉上一个条目的收尾零块，再追加新条目
+  let end = tarBuf.length;
+  while (end >= 512 && tarBuf.subarray(end - 512, end).every((b) => b === 0)) end -= 512;
+  return Buffer.concat([tarBuf.subarray(0, end), header, padded]);
+}
+
+// ── 生成补丁包 ────────────────────────────────────────────────────────
+
+const patchId = `${fromRef.replace(/[^0-9A-Za-z._-]/g, '_')}_to_${toRef.replace(/[^0-9A-Za-z._-]/g, '_')}`;
+const mtime = Math.floor(new Date(toDate).getTime() / 1000);
+
+fs.mkdirSync(outDir, { recursive: true });
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'linshe-patch-'));
+
+// git archive 不支持从文件读 pathspec，Windows 命令行又有长度上限；
+// 所以按字节切块多次导出，再把 tar 首尾相接（tar 允许直接拼接条目）。
+function stripTrailingZeros(buf) {
+  let end = buf.length;
+  while (end >= 512 && buf.subarray(end - 512, end).every((b) => b === 0)) end -= 512;
+  return buf.subarray(0, end);
+}
+
+function archiveInChunks(paths) {
+  const chunks = [];
+  let bucket = [];
+  let bytes = 0;
+
+  const flush = () => {
+    if (bucket.length === 0) return;
+    const out = path.join(tmpDir, `chunk-${chunks.length}.tar`);
+    // --literal-pathspecs：路径按字面量处理，避免被当成 glob
+    execFileSync('git', [
+      '--literal-pathspecs', 'archive', '--format=tar', '--prefix=files/',
+      `--output=${out}`, toSha, '--', ...bucket,
+    ], { stdio: ['ignore', 'ignore', 'inherit'] });
+    chunks.push(fs.readFileSync(out));
+    bucket = [];
+    bytes = 0;
+  };
+
+  for (const filePath of paths) {
+    const cost = Buffer.byteLength(filePath, 'utf8') + 3;
+    if (bytes + cost > 6000) flush();
+    bucket.push(filePath);
+    bytes += cost;
+  }
+  flush();
+  return Buffer.concat(chunks.map(stripTrailingZeros));
+}
+
+let archive = archiveInChunks(keepChanged);
+
+// ── 从包里读内容算哈希 ────────────────────────────────────────────────
+// 不能拿 git show 的字节来算：git archive 会按 core.autocrlf / .gitattributes
+// 做行尾转换（本仓在 Windows 上是 CRLF），于是"清单里的哈希"和"包里的内容"
+// 会对不上。清单必须描述载荷本身，所以直接解析 tar 取真实字节。
+
+function readTarEntries(buf) {
+  const entries = new Map();
+  let offset = 0;
+  while (offset + 512 <= buf.length) {
+    const block = buf.subarray(offset, offset + 512);
+    if (block.every((b) => b === 0)) break;
+    const name = block.subarray(0, 100).toString('utf8').replace(/\0.*$/, '');
+    const prefix = block.subarray(345, 500).toString('utf8').replace(/\0.*$/, '');
+    const size = parseInt(
+      block.subarray(124, 136).toString('ascii').replace(/\0.*$/, '').trim() || '0', 8,
+    ) || 0;
+    offset += 512;
+    entries.set(prefix ? `${prefix}/${name}` : name, buf.subarray(offset, offset + size));
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+const entries = readTarEntries(archive);
+const files = keepChanged.map((filePath) => {
+  const content = entries.get(`files/${filePath}`);
+  if (!content) throw new Error(`补丁包缺少文件内容：${filePath}`);
+  return {
+    path: filePath,
+    sha256: createHash('sha256').update(content).digest('hex'),
+    size: content.length,
+  };
+});
+
+const meta = {
+  schema: SCHEMA,
+  id: patchId,
+  channel,
+  from: (args.fromVersions || fromRef).split(',').map((s) => s.trim()).filter(Boolean),
+  to: toRef,
+  from_commit: fromSha.slice(0, 12),
+  to_commit: toSha.slice(0, 12),
+  created_at: new Date().toISOString(),
+  notes: args.notes || '',
+  files,
+  deleted: keepDeleted,
+  excluded: droppedChanged.length + droppedDeleted.length,
+};
+
+archive = appendEntry(archive, 'patch.json',
+  Buffer.from(JSON.stringify(meta, null, 2), 'utf8'), mtime);
+archive = Buffer.concat([archive, Buffer.alloc(1024)]);   // tar 收尾
+
+const gzPath = path.join(outDir, `${patchId}.tar.gz`);
+const gz = zlib.gzipSync(archive, { level: 9 });
+fs.writeFileSync(gzPath, gz);
+const gzSha = createHash('sha256').update(gz).digest('hex');
+
+// ── 更新清单 ──────────────────────────────────────────────────────────
+
+const manifestPath = path.join(outDir, 'index.json');
+let manifest = { schema: SCHEMA, channel, latest: null, patches: [] };
+if (fs.existsSync(manifestPath)) {
+  try {
+    const existing = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    if (existing && Array.isArray(existing.patches)) manifest = existing;
+  } catch {
+    console.warn('[patch] 现有 index.json 解析失败，将重建');
+  }
+}
+
+const entry = {
+  id: patchId,
+  channel,
+  from: meta.from,
+  to: toRef,
+  file: `${patchId}.tar.gz`,
+  size: gz.length,
+  sha256: gzSha,
+  notes: meta.notes,
+  created_at: meta.created_at,
+  files: files.length,
+  deleted: deleted.length,
+};
+
+manifest.schema = SCHEMA;
+manifest.channel = channel;
+manifest.patches = [entry, ...(manifest.patches || []).filter((p) => p && p.id !== patchId)];
+manifest.patches.sort((a, b) => String(b.created_at).localeCompare(String(a.created_at)));
+manifest.latest = manifest.patches[0]?.to ?? null;
+manifest.updated_at = new Date().toISOString();
+
+fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf8');
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+console.log(`[patch] ${fromRef} → ${toRef}`);
+console.log(`  变更文件 ${files.length} 个${keepDeleted.length ? `，删除 ${keepDeleted.length} 个` : ''}`
+  + (meta.excluded ? `（已排除构建产物/忽略项 ${meta.excluded} 个，本地重新构建会重新生成）` : ''));
+console.log(`  补丁包   ${gzPath}  (${(gz.length / 1024).toFixed(1)} KB)`);
+console.log(`  sha256   ${gzSha}`);
+console.log(`  清单     ${manifestPath}  (latest=${manifest.latest})`);


### PR DESCRIPTION
## 这个 PR 做了什么

给启动器加两条通道：**用户能方便地把问题交回来**，以及**新版本能小体积地发下去**。两者都不引入后端服务。

---

## 一、问题反馈（启动器新增「反馈」页）

**用户只写问题描述**，其余全部自动：

- **问题 ID**：本地生成 `LS-YYYYMMDD-XXXXXX`，写进 issue 标题，便于按 ID 检索同一个问题
- **环境信息**：启动器版本 / 当前 tag / 远程 tag / 操作系统 / Python / Node / 两个服务的运行状态 / 更新源
- **最近 200 行日志**：新增 `logbus` 全局环形缓冲，挂在 `LogWidget.append_line` 这一个入口上，
  运行日志页、版本页、MaiBot 页、构建输出的内容全部自动汇聚 —— 以后新增日志区也自动覆盖
- **提交前统一脱敏**：`sk-`、`Bearer`、`api_key=` / `token=` / `secret=`、Windows 用户名路径、
  以及任何 32 位以上连续随机串。**不能让用户把自己花钱买的密钥贴进公开 issue**

**提交顺序刻意为「先备齐，再试网页」**：

1. 先落盘 `feedback/<问题ID>.txt`
2. 先复制完整报告到剪贴板
3. 再探测反馈站点可达性（对 host 发 HEAD，3 秒超时）
4. 可达 → 打开预填 issue 页
5. 不可达 → **不打开死链接**，改用可配置的备用渠道（QQ 群 / 问卷 / B站），并提示"报告已在剪贴板，粘贴即可"

之所以这样排序：默认提交页是 GitHub，国内常常直连不上。无论后面网页能否打开，用户手里都必须
已经有一份完整报告，否则一点"提交"就卡死在死链接上。

提交地址是模板（`{slug}` `{issue_id}` `{title}` `{body}`），可整体换成 Gitee 等；模板里没有
`{body}` 的渠道（问卷/群链接）会被识别出来，可达时也提醒用户按 Ctrl+V 粘贴。

---

## 二、增量补丁（版本页新增「增量补丁」区）

- **打包**：`npm run build-patch -- --from v3.4.0 --to v3.4.1 --source-only --notes "…"`
  产出 `patches/<id>.tar.gz` + `patches/index.json`（含大小与 sha256），整个目录可直接当静态源发布
- **格式**：tar.gz（内含 `patch.json` + `files/<路径>`）。选它是因为 Node 侧用 `git archive` 写、
  Python 侧用 `tarfile` 读，**两边零第三方依赖**
- **落地**：清单拉取 → 下载 → sha256 校验 → 安全解包 → 逐个校验 → 覆盖（原文件先备份）→ 可一键回滚
- **安全**：拒绝绝对路径、`..` 穿越、符号链接/硬链接；版本白名单（补丁只对声明的 `from` 生效）；
  应用失败自动回滚
- **补丁源不需要服务器**。本地程序无法被推送，只能主动去拉，所以只需要一个它能访问到的静态落点：
  | 方式 | 填法 |
  |---|---|
  | 同仓库 patches 分支（默认，按 `repo_url` 自动推导） | 留空即可 |
  | 对象存储 / 自建站 / Gitee raw | `https://…/patches/` |
  | 本机或共享目录 | `D:\patches`、`\\nas\patches`（自动转 `file://`） |
  | 完全离线 | 不配源，直接点「导入补丁包…」选一个 `.tar.gz` |
- **直连失败会自动走本地代理**：复用 `git_manager` 那套本地代理探测并重试一次。原先只有 git
  走代理、补丁走 Qt 网络只认系统代理，会出现"版本能更新、补丁下不动"这种看起来毫无道理的现象
- **`--source-only`**：排除 `agent-core/public/**`（内容是哈希命名的 bundle，每次重建文件名全变），
  只发源码、产物由本地强制重新构建生成。实测 `5e3e0af→3b03b7b`：**866 KB → 421 KB**

---

## 注意事项

1. **补丁会覆盖项目文件**。原文件先备份到 `.patch-backup/<补丁ID>/`，可一键回滚，但请先确认用户
   没有未提交的本地改动（补丁按整文件替换，不做三方合并）。
2. **应用补丁后必须强制重新构建**。尤其配合 `--source-only` 时，前端产物没有随包下发，
   不重建会出现前后端版本不一致。UI 上的提示文案已写明。
3. **补丁是整文件替换，不是二进制 diff**。补丁体积 ≈ 变更文件的完整大小；对源码合适，
   若某次改动包含大二进制文件（模型、图片、字体），补丁会很大 —— 这种事前用 `--exclude` 排掉。
4. **补丁只有 sha256，没有签名**。哈希能防下载截断/损坏，不防恶意替换；安全性依赖 https 传输。
   若将来走公网自建源并担心投毒，建议再加签名校验。
5. **反馈默认不自动上传**。客户端不内置任何 token；提交动作是"打开预填页 + 剪贴板"。
   也因此**默认渠道（GitHub）国内可能打不开**，建议在「反馈」页配置备用渠道（QQ 群/问卷），
   或在 `feedback_issue_template` 里直接换成国内可直连的提交页。
6. **日志含最近 200 行**，可能夹带用户对话片段。凭据已脱敏，但介意隐私的用户可以取消勾选
   「附带最近 200 行日志」再提交。日志只在内存环形缓冲里，不落盘、不主动上报。
7. **新增三个配置项**（`launcher_config.json`，老配置会自动补默认值，无需手工迁移）：
   `patch_base_url`（留空=按 `repo_url` 推导）、`feedback_issue_template`、`feedback_channel_url`。
8. **无数据库 / 接口 / 协议变更**，纯启动器侧改动，不影响 agent-core 与 web-ui。
   但这些页面在启动器里，**需要重新用 PyInstaller 打包才会分发到用户**。

---

## 测试

补丁链路端到端（真实补丁包，非模拟）：

```
✓ 补丁源按 repo_url 推导（GitHub / Gitee / 未支持 / 空）
✓ 补丁源地址规整（http / 本地盘符 / UNC）
✓ 本地目录当源：清单读取 → 下载 + sha256 校验
✓ 应用：内容与补丁载荷逐字节一致
✓ 回滚：还原到打补丁前
✓ 版本白名单失效时拒绝
✓ 路径穿越包被拒
✓ --source-only：不含构建产物、逐条哈希一致、可应用可回滚
```

反馈链路：

```
✓ 报告生成：日志汇聚 + 服务状态 + 问题 ID
✓ 脱敏：sk- / Bearer / 用户名路径
✓ 可达：打开预填页 + 剪贴板/落盘就绪
✓ 不可达 + 有备用渠道：改开渠道并提示粘贴
✓ 不可达 + 无渠道：不开死链接，给出粘贴指引
✓ 不带正文的渠道：提示 Ctrl+V
✓ 空描述被拦下
```

启动器整窗离屏构造通过（7 页导航 `首页 日志 MaiBot 版本 设置 Q&A 反馈`）。

---

## 已知边界（后续可做，本 PR 不含）

- 补丁不做增量二进制 diff（整文件替换）；如需更小体积可后续引入 bsdiff 类方案
- 群聊的「客户端断开即中止生成」尚未做（本次只覆盖 1v1 聊天，见 #13）
- 反馈没有服务端接收（不做后端是有意为之）；若将来要落到自己的服务器，`feedback_issue_template`
  可以改成指向自建提交页
